### PR TITLE
The logging config that I used for sending fluentbit logs to Cloudwatch

### DIFF
--- a/aws-logging.yaml
+++ b/aws-logging.yaml
@@ -1,0 +1,44 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: aws-observability
+  labels:
+    aws-observability: enabled
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: aws-logging
+  namespace: aws-observability
+data:
+  # NEVER set this to true, or set only temporary
+  # it enables internal fluentbit logs that flood Cloudwatch
+  # and cause huge AWS bills 
+  # (see slack post https://this-is-biomage.slack.com/archives/C014YMUT6GN/p1646915799716329)
+  flb_log_cw: "false"
+  output.conf: |
+    [OUTPUT]
+        Name cloudwatch
+        Match *
+        region eu-west-1
+        log_group_name fluent-bit-cloudwatch
+        log_stream_name $(kubernetes['pod_name'])
+        auto_create_group true
+
+  parsers.conf: |
+    [PARSER]
+        Name         docker
+        Format       json
+        Time_Key     time
+        Time_Format  %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep    On
+  
+  filters.conf: |
+    [FILTER]
+        Name kubernetes
+        Match *
+        Merge_Log On
+        Buffer_Size 0
+        Kube_Meta_Cache_TTL 300s
+        Labels On
+        K8S-Logging.Exclude On

--- a/permissions.json
+++ b/permissions.json
@@ -1,0 +1,13 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Effect": "Allow",
+		"Action": [
+			"logs:CreateLogStream",
+			"logs:CreateLogGroup",
+			"logs:DescribeLogStreams",
+			"logs:PutLogEvents"
+		],
+		"Resource": "*"
+	}]
+}


### PR DESCRIPTION
# Background
#### Link to issue 
This is an investigation of a method that can be used to persist logs from pipeline and worker pods.
It is not production-ready, just a PoC. No need for reviews or merging at this stage.
Just raising this Draft PR to have a demo of what was done for enabling Fluent Bit logs to go to Cloudwatch.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR