### PR TITLE
added api permissions to remove sources bucket

### DIFF
--- a/cf/irsa-api-role.yaml
+++ b/cf/irsa-api-role.yaml
@@ -73,12 +73,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:GetObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
-                  - !Sub "arn:aws:s3:::plots-tables-${Environment}/*"
-                  - !Sub "arn:aws:s3:::cell-sets-${Environment}/*"
-                  - !Sub "arn:aws:s3:::processed-matrix-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-source-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::plots-tables-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}/*"
@@ -99,8 +93,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:PutObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::cell-sets-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
                   - !Sub "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::cell-sets-test-${Environment}-${AWS::AccountId}/*"
@@ -113,7 +105,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:GetObjectTagging"
                 Resource:
-                  - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::worker-results-test-${Environment}-${AWS::AccountId}/*"
 
@@ -124,10 +115,8 @@ Resources:
               - Effect: Allow
                 Action: "s3:DeleteObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
+                  - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-filtered-cells-test-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-test-${Environment}-${AWS::AccountId}/*"
 
@@ -138,7 +127,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:ListBucket"
                 Resource:
-                  - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}"
                   - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}-${AWS::AccountId}"
                   - !Sub "arn:aws:s3:::biomage-filtered-cells-test-${Environment}-${AWS::AccountId}"
 

--- a/cf/irsa-pipeline-role.yaml
+++ b/cf/irsa-pipeline-role.yaml
@@ -83,7 +83,7 @@ Resources:
                   - !Sub "arn:aws:s3:::biomage-source-test-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-test-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-filtered-cells-test-${Environment}-${AWS::AccountId}/*"
-                  
+
         - PolicyName: !Sub "can-upload-object-to-destination-bucket-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"
@@ -91,13 +91,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:PutObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
-                  - !Sub "arn:aws:s3:::plots-tables-${Environment}/*"
-                  - !Sub "arn:aws:s3:::processed-matrix-${Environment}/*"
-                  - !Sub "arn:aws:s3:::cell-sets-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-source-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-pipeline-debug-${Environment}/*"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::plots-tables-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::processed-matrix-${Environment}-${AWS::AccountId}/*"
@@ -120,7 +113,7 @@ Resources:
               - Effect: Allow
                 Action: "s3:DeleteObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}/*"
+                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-filtered-cells-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-filtered-cells-test-${Environment}-${AWS::AccountId}/*"
         - PolicyName: !Sub "can-modify-object-tags-${Environment}"
@@ -130,7 +123,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:PutObjectTagging"
                 Resource:
-                  - !Sub "arn:aws:s3:::plots-tables-${Environment}/*"
                   - !Sub "arn:aws:s3:::plots-tables-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::plots-tables-test-${Environment}-${AWS::AccountId}/*"
         - PolicyName: !Sub "can-push-to-sns-${Environment}"

--- a/cf/irsa-worker-role.yaml
+++ b/cf/irsa-worker-role.yaml
@@ -48,10 +48,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:ListBucket"
                 Resource:
-                  - !Sub "arn:aws:s3:::biomage-source-${Environment}"
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
-                  - !Sub "arn:aws:s3:::worker-results-${Environment}"
-                  - !Sub "arn:aws:s3:::processed-matrix-${Environment}"
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}"
@@ -68,10 +64,6 @@ Resources:
               - Effect: Allow
                 Action: "s3:GetObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::biomage-source-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
-                  - !Sub "arn:aws:s3:::cell-sets-${Environment}/*"
-                  - !Sub "arn:aws:s3:::processed-matrix-${Environment}/*"
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}/*"
@@ -92,7 +84,6 @@ Resources:
                   - "s3:PutObject"
                   - "s3:PutObjectTagging"
                 Resource:
-                  - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::worker-results-test-${Environment}-${AWS::AccountId}/*"
         - PolicyName: !Sub "can-read-from-worker-queue-${Environment}"


### PR DESCRIPTION
added permissions to the api to clean the sources bucket. Now that we do the merge in QC, the old r.rds remains in the sources bucket and it's being picked up as an additional sample. Removed also unneeded permissions because the buckets are gone.