### PR TITLE
Add Datadog API key only for Biomage environment

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -254,8 +254,14 @@ jobs:
           | yq w -d0 - myAccount.region --style=double "$AWS_REGION" \
           | yq w -d0 - myAccount.accountId --style=double "$AWS_ACCOUNT_ID" \
           | yq w -d0 - myAccount.acmCertificate --style=double "${{ secrets.ACM_CERTIFICATE_ARN }}" \
-          | yq w -d0 - myAccount.datadogApiKey --style=double "${{ secrets.DATADOG_API_KEY }}" \
           > infra/account-config.yaml
+
+          # Add Biomage-only config
+          if [[ $ENVIRONMENT_NAME = "Biomage" ]]
+          then
+            yq w -d0 infra/account-config.yaml myAccount.datadogApiKey --style=double "${{ secrets.DATADOG_API_KEY }}" \
+            > infra/account-config.yaml
+          fi
 
           cat infra/account-config.yaml
         env:


### PR DESCRIPTION
# Background
Datadog API key should only be added when deploying to Biomage environment.

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR