### PR TITLE
[BIOMAGE-2103] - Fix workflow failures notification

### DIFF
--- a/.github/workflows/backup-cognito-users.yaml
+++ b/.github/workflows/backup-cognito-users.yaml
@@ -56,7 +56,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: pipelines
+          channel: workflow-failures
           status: FAILED
           color: danger
  

--- a/.github/workflows/backup-cognito-users.yaml
+++ b/.github/workflows/backup-cognito-users.yaml
@@ -53,7 +53,7 @@ jobs:
         name: Send failure notification to Slack
         if: failure() && github.ref == 'refs/heads/master'
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: pipelines

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -16,65 +16,69 @@ jobs:
         environment-name: [Biomage]
     environment: ${{ matrix.environment-name }}
     steps:
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.region }}
+      - id: test-failure-notification
+        name: Testing failure notification. Should be removed.
+        run: exit 1
 
-      # If the step functions list is too close to its limit,
-      # this will remove the 500 older step functions.
-      - id: remove-old-state-machines
-        name: Remove old step functions
-        run: |-
-          state_machines_list=$(aws stepfunctions list-state-machines --output text)
-          threshold=500
-          maximum=$((10000 - $threshold))
-          count=$(echo $state_machines_list | grep -o 'arn:aws:states:' | wc -l)
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ env.region }}
 
-          echo $count
+      # # If the step functions list is too close to its limit,
+      # # this will remove the 500 older step functions.
+      # - id: remove-old-state-machines
+      #   name: Remove old step functions
+      #   run: |-
+      #     state_machines_list=$(aws stepfunctions list-state-machines --output text)
+      #     threshold=500
+      #     maximum=$((10000 - $threshold))
+      #     count=$(echo $state_machines_list | grep -o 'arn:aws:states:' | wc -l)
 
-          if (($count > $maximum))
-          then
-            echo "$count higher than the maximum, so deleting $threshold state machines"
-            echo $state_machines_list \
-              | sed 's/STATEMACHINES/\n STATEMACHINES/g' \
-              | sort -k2 \
-              | head -$threshold \
-              | awk '{print $4}' \
-              | xargs -I {} aws stepfunctions delete-state-machine --state-machine-arn {}
-            echo "Finished deleting state machines"
-          else
-            echo "No state machines deleted"
-          fi
+      #     echo $count
 
-      # If the activities list is too close to its limit,
-      # this will remove the 500 older activities.
-      - id: remove-old-activities
-        name: Remove old activities
-        run: |-
-          activities_list=$(aws stepfunctions list-activities --output text)
-          threshold=500
-          maximum=$((10000 - $threshold))
-          count=$(echo $activities_list | grep -o 'arn:aws:states:' | wc -l)
+      #     if (($count > $maximum))
+      #     then
+      #       echo "$count higher than the maximum, so deleting $threshold state machines"
+      #       echo $state_machines_list \
+      #         | sed 's/STATEMACHINES/\n STATEMACHINES/g' \
+      #         | sort -k2 \
+      #         | head -$threshold \
+      #         | awk '{print $4}' \
+      #         | xargs -I {} aws stepfunctions delete-state-machine --state-machine-arn {}
+      #       echo "Finished deleting state machines"
+      #     else
+      #       echo "No state machines deleted"
+      #     fi
 
-          echo $count
+      # # If the activities list is too close to its limit,
+      # # this will remove the 500 older activities.
+      # - id: remove-old-activities
+      #   name: Remove old activities
+      #   run: |-
+      #     activities_list=$(aws stepfunctions list-activities --output text)
+      #     threshold=500
+      #     maximum=$((10000 - $threshold))
+      #     count=$(echo $activities_list | grep -o 'arn:aws:states:' | wc -l)
 
-          if (($count > $maximum))
-          then
-            echo "$count higher than the maximum, so deleting $threshold activities"
-            echo $activities_list \
-              | sed 's/ACTIVITIES/\n ACTIVITIES/g' \
-              | sort -k2 \
-              | head -$threshold \
-              | awk '{print $2}' \
-              | xargs -I {} aws stepfunctions delete-activity --activity-arn {}
-            echo "Finished deleting activities"
-          else
-            echo "No activities deleted"
-          fi
+      #     echo $count
+
+      #     if (($count > $maximum))
+      #     then
+      #       echo "$count higher than the maximum, so deleting $threshold activities"
+      #       echo $activities_list \
+      #         | sed 's/ACTIVITIES/\n ACTIVITIES/g' \
+      #         | sort -k2 \
+      #         | head -$threshold \
+      #         | awk '{print $2}' \
+      #         | xargs -I {} aws stepfunctions delete-activity --activity-arn {}
+      #       echo "Finished deleting activities"
+      #     else
+      #       echo "No activities deleted"
+      #     fi
 
       - id: send-to-slack
         name: Send failure notification to Slack

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -8,7 +8,7 @@ env:
   region: ${{ secrets.AWS_REGION }}
 
 jobs:
-  run-e2e:
+  delete-unused-step-functions:
     name: Delete old step functions
     runs-on: ubuntu-20.04
     strategy:
@@ -16,6 +16,11 @@ jobs:
         environment-name: [Biomage]
     environment: ${{ matrix.environment-name }}
     steps:
+
+      - id: test-error
+        name: Test error
+        run: exit 1
+
       - id: setup-aws
         name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -78,7 +83,7 @@ jobs:
 
       - id: send-to-slack
         name: Send failure notification to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - id: send-to-slack
         name: Send failure notification to Slack
-        # if: failure() && github.ref == 'refs/heads/master'
+        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - id: send-to-slack
         name: Send failure notification to Slack
-        if: failure() && github.ref == 'refs/heads/master'
+        # if: failure() && github.ref == 'refs/heads/master'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -16,73 +16,69 @@ jobs:
         environment-name: [Biomage]
     environment: ${{ matrix.environment-name }}
     steps:
-      - id: test-failure-notification
-        name: Testing failure notification. Should be removed.
-        run: exit 1
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.region }}
 
-      # - id: setup-aws
-      #   name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ env.region }}
+      # If the step functions list is too close to its limit,
+      # this will remove the 500 older step functions.
+      - id: remove-old-state-machines
+        name: Remove old step functions
+        run: |-
+          state_machines_list=$(aws stepfunctions list-state-machines --output text)
+          threshold=500
+          maximum=$((10000 - $threshold))
+          count=$(echo $state_machines_list | grep -o 'arn:aws:states:' | wc -l)
 
-      # # If the step functions list is too close to its limit,
-      # # this will remove the 500 older step functions.
-      # - id: remove-old-state-machines
-      #   name: Remove old step functions
-      #   run: |-
-      #     state_machines_list=$(aws stepfunctions list-state-machines --output text)
-      #     threshold=500
-      #     maximum=$((10000 - $threshold))
-      #     count=$(echo $state_machines_list | grep -o 'arn:aws:states:' | wc -l)
+          echo $count
 
-      #     echo $count
+          if (($count > $maximum))
+          then
+            echo "$count higher than the maximum, so deleting $threshold state machines"
+            echo $state_machines_list \
+              | sed 's/STATEMACHINES/\n STATEMACHINES/g' \
+              | sort -k2 \
+              | head -$threshold \
+              | awk '{print $4}' \
+              | xargs -I {} aws stepfunctions delete-state-machine --state-machine-arn {}
+            echo "Finished deleting state machines"
+          else
+            echo "No state machines deleted"
+          fi
 
-      #     if (($count > $maximum))
-      #     then
-      #       echo "$count higher than the maximum, so deleting $threshold state machines"
-      #       echo $state_machines_list \
-      #         | sed 's/STATEMACHINES/\n STATEMACHINES/g' \
-      #         | sort -k2 \
-      #         | head -$threshold \
-      #         | awk '{print $4}' \
-      #         | xargs -I {} aws stepfunctions delete-state-machine --state-machine-arn {}
-      #       echo "Finished deleting state machines"
-      #     else
-      #       echo "No state machines deleted"
-      #     fi
+      # If the activities list is too close to its limit,
+      # this will remove the 500 older activities.
+      - id: remove-old-activities
+        name: Remove old activities
+        run: |-
+          activities_list=$(aws stepfunctions list-activities --output text)
+          threshold=500
+          maximum=$((10000 - $threshold))
+          count=$(echo $activities_list | grep -o 'arn:aws:states:' | wc -l)
 
-      # # If the activities list is too close to its limit,
-      # # this will remove the 500 older activities.
-      # - id: remove-old-activities
-      #   name: Remove old activities
-      #   run: |-
-      #     activities_list=$(aws stepfunctions list-activities --output text)
-      #     threshold=500
-      #     maximum=$((10000 - $threshold))
-      #     count=$(echo $activities_list | grep -o 'arn:aws:states:' | wc -l)
+          echo $count
 
-      #     echo $count
-
-      #     if (($count > $maximum))
-      #     then
-      #       echo "$count higher than the maximum, so deleting $threshold activities"
-      #       echo $activities_list \
-      #         | sed 's/ACTIVITIES/\n ACTIVITIES/g' \
-      #         | sort -k2 \
-      #         | head -$threshold \
-      #         | awk '{print $2}' \
-      #         | xargs -I {} aws stepfunctions delete-activity --activity-arn {}
-      #       echo "Finished deleting activities"
-      #     else
-      #       echo "No activities deleted"
-      #     fi
+          if (($count > $maximum))
+          then
+            echo "$count higher than the maximum, so deleting $threshold activities"
+            echo $activities_list \
+              | sed 's/ACTIVITIES/\n ACTIVITIES/g' \
+              | sort -k2 \
+              | head -$threshold \
+              | awk '{print $2}' \
+              | xargs -I {} aws stepfunctions delete-activity --activity-arn {}
+            echo "Finished deleting activities"
+          else
+            echo "No activities deleted"
+          fi
 
       - id: send-to-slack
         name: Send failure notification to Slack
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/master'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -83,6 +83,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: pipelines
+          channel: workflow-failures
           status: FAILED
           color: danger

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -80,7 +80,7 @@ jobs:
         name: Send failure notification to Slack
         if: failure() && github.ref == 'refs/heads/master'
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: pipelines

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -16,11 +16,6 @@ jobs:
         environment-name: [Biomage]
     environment: ${{ matrix.environment-name }}
     steps:
-
-      - id: test-error
-        name: Test error
-        run: exit 1
-
       - id: setup-aws
         name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -83,7 +78,7 @@ jobs:
 
       - id: send-to-slack
         name: Send failure notification to Slack
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/master'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -326,7 +326,7 @@ jobs:
       - id: send-to-slack
         name: Send failure notification to Slack on failure
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: workflow-failures

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -528,7 +528,7 @@ jobs:
       - id: send-to-slack
         name: Send failure notification to Slack on failure
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: pipelines

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -531,6 +531,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: pipelines
+          channel: workflow-failures
           status: FAILED
           color: danger


### PR DESCRIPTION
# Background
#### Link to issue 
We are not notified of failing workflows anymore because we have not setup the bot token. This PR replaces the token with a new one. I've also inserted the bot token as a repository secret.

#### Link to staging deployment URL 
https://biomage.atlassian.net/browse/BIOMAGE-2103

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR