### PR TITLE
[BIOMAGE-2154] - Add cluster logging

### DIFF
--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -125,6 +125,9 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
+          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+          # We do not want to log everything for costs/security concerns
+
           # Using yq4 because yq3 does not have capability to substitute strings inside documents
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
@@ -152,6 +155,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |-
+          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
           # Using yq4 because yq3 does not have capability to substitute strings inside documents
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -92,7 +92,7 @@ jobs:
           sudo mv /tmp/eksctl /usr/local/bin
 
       - id: setup-cluster-cloudwatch-logging-policy
-        name: Setup role required for cluster to log to Cloudwatch
+        name: Setup permissions required for cluster to log to Cloudwatch
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           parameter-overrides: "Environment=${{ matrix.environment-type }}"
@@ -104,7 +104,7 @@ jobs:
       # Setting up log forwarding for pods hosted in EC2 nodes
       - id: create-fluent-bit-namespace
         name: Create namespace for node FluentBit deployment
-        run: kubectl -f apply infra/cluster-logging/node-fluentbit-namespace.yaml
+        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
       - id: create-service-account-for-node-fluent-bit
         name: Create service account for node FluentBit
@@ -128,7 +128,7 @@ jobs:
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-          kubectl -f apply  infra/cluster-logging/node-fluentbit-config.yaml
+          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
       # Setting up log forwarding for pods hosted on Fargate nodes
       - id: attach-pod-execution-role-name
@@ -136,17 +136,15 @@ jobs:
         env:
           LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
         run: |-
-          echo "LOGGING_POLICY_ARN: $LOGGING_POLICY_ARN"
-
           # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
           # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
           # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-          # POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-          #   --cluster-name biomage-$CLUSTER_ENV \
-          #   --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+            --cluster-name biomage-$CLUSTER_ENV \
+            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-          # aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
       - id: deploy-fargate-fluent-bit-config
         name: Deploy FluentBit config for Fargate pods
@@ -157,28 +155,24 @@ jobs:
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-          echo "AWS_REGION: $AWS_REGION"
-          echo "CLUSTER_ENV: $CLUSTER_ENV"
-          cat infra/cluster-logging/fargate-fluentbit-config.yaml
-
-          # kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
       # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      # - id: setup-datadog-cluster-agent
-      #   name: Setup Datadog cluster agent
-      #   run: |-
-      #     helm repo add datadog https://helm.datadoghq.com
-      #     helm repo update
-      #     helm upgrade datadog-agent datadog/datadog \
-      #       -f infra/datadog/cluster-agent-values.yaml \
-      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
-      #       --install
+      - id: setup-datadog-cluster-agent
+        name: Setup Datadog cluster agent
+        run: |-
+          helm repo add datadog https://helm.datadoghq.com
+          helm repo update
+          helm upgrade datadog-agent datadog/datadog \
+            -f infra/datadog/cluster-agent-values.yaml \
+            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+            --set datadog.clusterName=biomage-$CLUSTER_ENV \
+            --install
 
-      # - id: setup-datadog-sidecar-permissions
-      #   name: Setup Datadog sidecar permissions
-      #   run: |-
-      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      - id: setup-datadog-sidecar-permissions
+        name: Setup Datadog sidecar permissions
+        run: |-
+          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -117,6 +117,7 @@ jobs:
             --cluster biomage-$CLUSTER_ENV \
             --role-name irsa-fluent-bit-$CLUSTER_ENV \
             --attach-policy-arn $LOGGING_POLICY_ARN \
+            --override-existing-serviceaccounts \
             --approve
 
       - id: deploy-node-fluent-bit

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -99,6 +99,7 @@ jobs:
           name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
           template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
           no-fail-on-empty-changeset: "1"
+          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
       # # Setting up log forwarding for pods hosted in EC2 nodes
       # - id: create-fluent-bit-namespace

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -80,16 +80,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # - id: install-eksctl
-      #   name: Install eksctl
-      #   run: |-
-      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-      #     sudo mv /tmp/eksctl /usr/local/bin
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
 
       - id: setup-cluster-cloudwatch-logging-policy
         name: Setup role required for cluster to log to Cloudwatch
@@ -101,23 +101,23 @@ jobs:
           no-fail-on-empty-changeset: "1"
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      # # Setting up log forwarding for pods hosted in EC2 nodes
-      # - id: create-fluent-bit-namespace
-      #   name: Create namespace for node FluentBit deployment
-      #   run: kubectl -f apply  infra/cluster-logging/node-fluentbit-namespace.yaml
+      # Setting up log forwarding for pods hosted in EC2 nodes
+      - id: create-fluent-bit-namespace
+        name: Create namespace for node FluentBit deployment
+        run: kubectl -f apply infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      # - id: create-service-account-for-node-fluent-bit
-      #   name: Create service account for node FluentBit
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     eksctl create iamserviceaccount \
-      #       --name fluent-bit \
-      #       --namespace node-logging \
-      #       --cluster biomage-$CLUSTER_ENV \
-      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
-      #       --attach-policy-arn $LOGGING_POLICY_ARN \
-      #       --approve
+      - id: create-service-account-for-node-fluent-bit
+        name: Create service account for node FluentBit
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          eksctl create iamserviceaccount \
+            --name fluent-bit \
+            --namespace node-logging \
+            --cluster biomage-$CLUSTER_ENV \
+            --role-name irsa-fluent-bit-$CLUSTER_ENV \
+            --attach-policy-arn $LOGGING_POLICY_ARN \
+            --approve
 
       - id: deploy-node-fluent-bit
         name: Deploy FluentBit for EC2 nodes
@@ -128,11 +128,7 @@ jobs:
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-          echo "AWS_REGION: $AWS_REGION"
-          echo "CLUSTER_ENV: $CLUSTER_ENV"
-          cat infra/cluster-logging/node-fluentbit-config.yaml
-
-          # kubectl -f apply  infra/cluster-logging/node-fluentbit-config.yaml
+          kubectl -f apply  infra/cluster-logging/node-fluentbit-config.yaml
 
       # Setting up log forwarding for pods hosted on Fargate nodes
       - id: attach-pod-execution-role-name
@@ -153,7 +149,7 @@ jobs:
           # aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
       - id: deploy-fargate-fluent-bit-config
-        name: Create and deploy FluentBit config for Fargate pods
+        name: Deploy FluentBit config for Fargate pods
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |-

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -80,16 +80,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
       - id: setup-cluster-cloudwatch-logging-policy
         name: Setup role required for cluster to log to Cloudwatch
@@ -100,23 +100,23 @@ jobs:
           template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
           no-fail-on-empty-changeset: "1"
 
-      # Setting up log forwarding for pods hosted in EC2 nodes
-      - id: create-fluent-bit-namespace
-        name: Create namespace for node FluentBit deployment
-        run: kubectl -f apply  infra/cluster-logging/node-fluentbit-namespace.yaml
+      # # Setting up log forwarding for pods hosted in EC2 nodes
+      # - id: create-fluent-bit-namespace
+      #   name: Create namespace for node FluentBit deployment
+      #   run: kubectl -f apply  infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      - id: create-service-account-for-node-fluent-bit
-        name: Create service account for node FluentBit
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          eksctl create iamserviceaccount \
-            --name fluent-bit \
-            --namespace node-logging \
-            --cluster biomage-$CLUSTER_ENV \
-            --role-name irsa-fluent-bit-$CLUSTER_ENV \
-            --attach-policy-arn $LOGGING_POLICY_ARN \
-            --approve
+      # - id: create-service-account-for-node-fluent-bit
+      #   name: Create service account for node FluentBit
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     eksctl create iamserviceaccount \
+      #       --name fluent-bit \
+      #       --namespace node-logging \
+      #       --cluster biomage-$CLUSTER_ENV \
+      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
+      #       --attach-policy-arn $LOGGING_POLICY_ARN \
+      #       --approve
 
       - id: deploy-node-fluent-bit
         name: Deploy FluentBit for EC2 nodes
@@ -127,7 +127,11 @@ jobs:
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-          kubectl -f apply  infra/cluster-logging/node-fluentbit-config.yaml
+          echo "AWS_REGION: $AWS_REGION"
+          echo "CLUSTER_ENV: $CLUSTER_ENV"
+          cat infra/cluster-logging/node-fluentbit-config.yaml
+
+          # kubectl -f apply  infra/cluster-logging/node-fluentbit-config.yaml
 
       # Setting up log forwarding for pods hosted on Fargate nodes
       - id: attach-pod-execution-role-name
@@ -135,15 +139,17 @@ jobs:
         env:
           LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
         run: |-
+          echo "LOGGING_POLICY_ARN: $LOGGING_POLICY_ARN"
+
           # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
           # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
           # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-            --cluster-name biomage-$CLUSTER_ENV \
-            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+          # POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+          #   --cluster-name biomage-$CLUSTER_ENV \
+          #   --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+          # aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
       - id: deploy-fargate-fluent-bit-config
         name: Create and deploy FluentBit config for Fargate pods
@@ -154,24 +160,28 @@ jobs:
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+          echo "AWS_REGION: $AWS_REGION"
+          echo "CLUSTER_ENV: $CLUSTER_ENV"
+          cat infra/cluster-logging/fargate-fluentbit-config.yaml
+
+          # kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
       # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      - id: setup-datadog-cluster-agent
-        name: Setup Datadog cluster agent
-        run: |-
-          helm repo add datadog https://helm.datadoghq.com
-          helm repo update
-          helm upgrade datadog-agent datadog/datadog \
-            -f infra/datadog/cluster-agent-values.yaml \
-            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-            --set datadog.clusterName=biomage-$CLUSTER_ENV \
-            --install
+      # - id: setup-datadog-cluster-agent
+      #   name: Setup Datadog cluster agent
+      #   run: |-
+      #     helm repo add datadog https://helm.datadoghq.com
+      #     helm repo update
+      #     helm upgrade datadog-agent datadog/datadog \
+      #       -f infra/datadog/cluster-agent-values.yaml \
+      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
+      #       --install
 
-      - id: setup-datadog-sidecar-permissions
-        name: Setup Datadog sidecar permissions
-        run: |-
-          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      # - id: setup-datadog-sidecar-permissions
+      #   name: Setup Datadog sidecar permissions
+      #   run: |-
+      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -128,7 +128,6 @@ jobs:
           # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
           # We do not want to log everything for costs/security concerns
 
-          # Using yq4 because yq3 does not have capability to substitute strings inside documents
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
@@ -150,13 +149,12 @@ jobs:
 
           aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      - id: deploy-fargate-fluent-bit-config
+      - id: deploy-fargate-fluent-bit
         name: Deploy FluentBit config for Fargate pods
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |-
           # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-          # Using yq4 because yq3 does not have capability to substitute strings inside documents
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
           yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -85,12 +85,56 @@ jobs:
         run: |-
           aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: get-pod-execution-role-name
-        name: Get pod execution role name
-        env:
-          AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
+      - id: install-eksctl
+        name: Install eksctl
         run: |-
-          # Get pod execution role name for cluster.
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
+
+      - id: setup-cluster-cloudwatch-logging-policy
+        name: Setup role required for cluster to log to Cloudwatch
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }}"
+          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+          no-fail-on-empty-changeset: "1"
+
+      # Setting up log forwarding for pods hosted in EC2 nodes
+      - id: create-fluent-bit-namespace
+        name: Create namespace for node FluentBit deployment
+        run: kubectl -f apply  infra/cluster-logging/node-fluentbit-namespace.yaml
+
+      - id: create-service-account-for-node-fluent-bit
+        name: Create service account for node FluentBit
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          eksctl create iamserviceaccount \
+            --name fluent-bit \
+            --namespace node-logging \
+            --cluster biomage-$CLUSTER_ENV \
+            --role-name irsa-fluent-bit-$CLUSTER_ENV \
+            --attach-policy-arn $LOGGING_POLICY_ARN \
+            --approve
+
+      - id: deploy-node-fluent-bit
+        name: Deploy FluentBit for EC2 nodes
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          # Using yq4 because yq3 does not have capability to substitute strings inside documents
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+
+          kubectl -f apply  infra/cluster-logging/node-fluentbit-config.yaml
+
+      # Setting up log forwarding for pods hosted on Fargate nodes
+      - id: attach-pod-execution-role-name
+        name: Attach logging policy to pod execution role
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
           # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
           # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
           # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
@@ -99,29 +143,20 @@ jobs:
             --cluster-name biomage-$CLUSTER_ENV \
             --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-          echo "::set-output name=name::$POD_EXEC_ROLE_NAME"
+          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      - id: setup-cluster-cloudwatch-logging-role
-        name: Setup role required for cluster to log to Cloudwatch
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }},PodExecutionRoleName=${{ steps.get-pod-execution-role-name.outputs.name }}"
-          name: "cluster-cloudwatch-logging-role-${{ matrix.environment-type }}"
-          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-          no-fail-on-empty-changeset: "1"
-
-      - id: create-and-deploy-fluentbit-config
-        name: Create and deploy FluentBit config
+      - id: deploy-fargate-fluent-bit-config
+        name: Create and deploy FluentBit config for Fargate pods
         env:
-          AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |-
-          # Using YQ4 because YQ3 does not have capability to substitute strings inside documents
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+          # Using yq4 because yq3 does not have capability to substitute strings inside documents
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
           kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
+      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
       - id: setup-datadog-cluster-agent
         name: Setup Datadog cluster agent
         run: |-

--- a/infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml
+++ b/infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml
@@ -29,10 +29,6 @@ Resources:
               - "logs:CreateLogGroup"
               - "logs:DescribeLogStreams"
               - "logs:PutRetentionPolicy"
-            Resource:
-              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/platform-logs/${Environment}"
-          - Effect: Allow
-            Action:
               - "logs:PutLogEvents"
             Resource:
-              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/platform-logs/${Environment}:log-stream:*"
+              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/platform-logs/${Environment}*"

--- a/infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml
+++ b/infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml
@@ -9,8 +9,6 @@ Parameters:
       - staging
       - production
     Description: The environment for which the logs need to be created.
-  PodExecutionRoleName:
-    Type: String
 
 Outputs:
   PolicyARN:
@@ -38,5 +36,3 @@ Resources:
               - "logs:PutLogEvents"
             Resource:
               - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/platform-logs/${Environment}:log-stream:*"
-      Roles:
-        - !Ref PodExecutionRoleName

--- a/infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml
+++ b/infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml
@@ -12,11 +12,16 @@ Parameters:
   PodExecutionRoleName:
     Type: String
 
+Outputs:
+  PolicyARN:
+    Description: ARN of PlatformLogToCloudwatchPolicy
+    Value: !Ref PlatformLogToCloudwatchPolicy
+
 Resources:
-  PlatformLogToCloudwatchRole:
-    Type: "AWS::IAM::Policy"
+  PlatformLogToCloudwatchPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      PolicyName: !Sub "platform-log-to-cloudwatch-${Environment}"
+      ManagedPolicyName: !Sub "platform-log-to-cloudwatch-${Environment}"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/infra/cluster-logging/fargate-fluentbit-config.yaml
+++ b/infra/cluster-logging/fargate-fluentbit-config.yaml
@@ -44,11 +44,16 @@ data:
         Name   grep
         Match  kube.*
         Exclude log No activity ARN label set yet
-    # Exclude logs from worker pods in standby
+    # Exclude logs from Python worker containers in standby
     [FILTER]
         Name   grep
         Match  kube.*
         Exclude log No experiment ID label set yet
+    # Exclude logs from R worker containers in standby
+    [FILTER]
+        Name   grep
+        Match  kube.*
+        Exclude log Experiment not yet assigned
   output.conf: |
     [OUTPUT]
         Name cloudwatch

--- a/infra/cluster-logging/fargate-fluentbit-config.yaml
+++ b/infra/cluster-logging/fargate-fluentbit-config.yaml
@@ -34,33 +34,38 @@ data:
         Merge_Log           On
         Buffer_Size         0
         Kube_Meta_Cache_TTL 5s
+
     # Include only pipeline or worker pods
     [FILTER]
         Name   grep
         Match  kube.*
         Regex  $kubernetes['container_name'] (pipeline|worker|worker-r)
+
     # Exclude logs from pipline pods in standby
     [FILTER]
         Name   grep
         Match  kube.*
         Exclude log No activity ARN label set yet
+
     # Exclude logs from Python worker containers in standby
     [FILTER]
         Name   grep
         Match  kube.*
         Exclude log No experiment ID label set yet
+
     # Exclude logs from R worker containers in standby
     [FILTER]
         Name   grep
         Match  kube.*
         Exclude log Experiment not yet assigned
+
   output.conf: |
     [OUTPUT]
         Name cloudwatch
         Match kube.*
-        region AWS_REGION
+        region CI_AWS_REGION
         auto_create_group true
         log_retention_days 3
         log_key log
-        log_group_name /platform-logs/CLUSTER_ENV
+        log_group_name /platform-logs/CI_CLUSTER_ENV
         log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['labels']['experimentId'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])

--- a/infra/cluster-logging/node-fluentbit-config.yaml
+++ b/infra/cluster-logging/node-fluentbit-config.yaml
@@ -1,0 +1,247 @@
+#Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-pod-env
+  namespace: node-logging
+data:
+  cluster.name: 'biomage-CI_CLUSTER_ENV'
+  http.port: ''
+  http.server: 'Off'
+  logs.region: 'CI_AWS_REGION'
+  read.head: 'Off'
+  read.tail: 'On'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-role
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - pods/logs
+      - nodes
+      - nodes/proxy
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-role
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: node-logging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: node-logging
+  labels:
+    k8s-app: fluent-bit
+data:
+  application-log.conf: |
+    [INPUT]
+        Name                tail
+        Tag                 kube.*
+        Path                /var/log/containers/api*.log
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  container_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_container.db
+        Mem_Buf_Limit       50MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Rotate_Wait         30
+        storage.type        filesystem
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_processed
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude Off
+        Labels              Off
+        Annotations         Off
+        Use_Kubelet         On
+        Kubelet_Port        10250
+        Buffer_Size         0
+
+    [FILTER]
+        Name   grep
+        Match  kube.*
+        Regex  $kubernetes['container_name'] (biomage-node-chart)
+
+    [OUTPUT]
+        Name cloudwatch
+        Match kube.*
+        region CI_AWS_REGION
+        auto_create_group true
+        log_retention_days 3
+        log_key log
+        log_group_name /platform-logs/CI_CLUSTER_ENV
+        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
+  flb_log_cw: 'false'
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush                     5
+        Log_Level                 info
+        Daemon                    off
+        Parsers_File              parsers.conf
+        HTTP_Server               ${HTTP_SERVER}
+        HTTP_Listen               0.0.0.0
+        HTTP_Port                 ${HTTP_PORT}
+        storage.path              /var/fluent-bit/state/flb-storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+
+    @INCLUDE application-log.conf
+  parsers.conf: |
+    [PARSER]
+        Name                docker
+        Format              json
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+        Name                container_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: node-logging
+  labels:
+    k8s-app: fluent-bit
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+        - name: fluent-bit
+          image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
+          imagePullPolicy: Always
+          env:
+            - name: AWS_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: logs.region
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: cluster.name
+            - name: HTTP_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.server
+            - name: HTTP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.port
+            - name: READ_FROM_HEAD
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.head
+            - name: READ_FROM_TAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.tail
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: CI_VERSION
+              value: "k8s/1.3.11"
+          resources:
+              limits:
+                memory: 200Mi
+              requests:
+                cpu: 500m
+                memory: 100Mi
+          volumeMounts:
+            # Please don't change below read-only permissions
+            - name: fluentbitstate
+              mountPath: /var/fluent-bit/state
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/etc/
+            - name: runlogjournal
+              mountPath: /run/log/journal
+              readOnly: true
+            - name: dmesg
+              mountPath: /var/log/dmesg
+              readOnly: true
+      terminationGracePeriodSeconds: 10
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      volumes:
+        - name: fluentbitstate
+          hostPath:
+            path: /var/fluent-bit/state
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-config
+        - name: runlogjournal
+          hostPath:
+            path: /run/log/journal
+        - name: dmesg
+          hostPath:
+            path: /var/log/dmesg
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/infra/cluster-logging/node-fluentbit-config.yaml
+++ b/infra/cluster-logging/node-fluentbit-config.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluent-bit-pod-env
+  name: fluent-bit-pod-config
   namespace: node-logging
 data:
   cluster.name: 'biomage-CI_CLUSTER_ENV'
@@ -156,32 +156,32 @@ spec:
             - name: AWS_REGION
               valueFrom:
                 configMapKeyRef:
-                  name: fluent-bit-cluster-info
+                  name: fluent-bit-pod-config
                   key: logs.region
             - name: CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
-                  name: fluent-bit-cluster-info
+                  name: fluent-bit-pod-config
                   key: cluster.name
             - name: HTTP_SERVER
               valueFrom:
                 configMapKeyRef:
-                  name: fluent-bit-cluster-info
+                  name: fluent-bit-pod-config
                   key: http.server
             - name: HTTP_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: fluent-bit-cluster-info
+                  name: fluent-bit-pod-config
                   key: http.port
             - name: READ_FROM_HEAD
               valueFrom:
                 configMapKeyRef:
-                  name: fluent-bit-cluster-info
+                  name: fluent-bit-pod-config
                   key: read.head
             - name: READ_FROM_TAIL
               valueFrom:
                 configMapKeyRef:
-                  name: fluent-bit-cluster-info
+                  name: fluent-bit-pod-config
                   key: read.tail
             - name: HOST_NAME
               valueFrom:

--- a/infra/cluster-logging/node-fluentbit-namespace.yaml
+++ b/infra/cluster-logging/node-fluentbit-namespace.yaml
@@ -1,0 +1,7 @@
+#Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: node-logging
+  labels:
+    name: node-logging


### PR DESCRIPTION
# Background
This PR installs FluentBit and corrresponding config into the cluster to forward API logs to Cloudwatch.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2154

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR