### PR TITLE
[BIOMAGE-2194] Remove unneeded ingress annotations

### DIFF
--- a/charts/nodejs/values.yaml
+++ b/charts/nodejs/values.yaml
@@ -35,9 +35,6 @@ serviceAccount:
 ingress:
   tls:
     enabled: true
-  annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
 
 livenessProbe:
   path: "/"

--- a/infra/aws-elb-503-subscription-endpoint/templates/ingress.yaml
+++ b/infra/aws-elb-503-subscription-endpoint/templates/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/group.order: '1000'
-    alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/actions.response-503: >
       {"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"503","messageBody":"The subscription endpoint is not available yet."}}
 spec:


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2194

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR