### PR TITLE
Insert `target-type: ip` annotation back into K8s

### DIFF
--- a/charts/nodejs/templates/ingress.yaml
+++ b/charts/nodejs/templates/ingress.yaml
@@ -29,6 +29,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: "{{ .Values.loadBalancerHealthCheck.successThreshold }}"
     alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ .Values.loadBalancerHealthCheck.failureThreshold }}"
     alb.ingress.kubernetes.io/group.name: {{ .Values.kubernetes.env }}
+    alb.ingress.kubernetes.io/target-type: ip
 spec:
   rules:
   - host: {{ template "hostname" . }}


### PR DESCRIPTION
# Background
#### Link to issue 
Staging is broken because a required Kubernetes annotation is deleted from the ingress definition. This PR adds that annotation back.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR