### PR TITLE
Aggregating all api logs into a single stream

### DIFF
--- a/infra/cluster-logging/node-fluentbit-config.yaml
+++ b/infra/cluster-logging/node-fluentbit-config.yaml
@@ -97,7 +97,7 @@ data:
         log_retention_days 3
         log_key log
         log_group_name /platform-logs/CI_CLUSTER_ENV
-        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
+        log_stream_name $(kubernetes['namespace_name'])
   flb_log_cw: 'false'
   fluent-bit.conf: |
     [SERVICE]


### PR DESCRIPTION
I'm aggregating all the api pods logs into a single stream. I don't find any use case where one would like to see them separately. If we do find such a use case we can always make a log group of all of them (instead of just dumping them together into staging/production logs)