### PR TITLE
[BIOMAGE-2218] Select only r6i family instances

### DIFF
--- a/cf/batch.yaml
+++ b/cf/batch.yaml
@@ -26,7 +26,12 @@ Resources:
         MaxvCpus: 128
         InstanceRole: !Sub "pipeline-instance-profile-${Environment}"
         InstanceTypes:
-          - optimal
+          - r6i.xlarge
+          - r6i.2xlarge
+          - r6i.4xlarge
+          - r6i.8xlarge
+          - r6i.12xlarge
+          - r6i.16xlarge
         SecurityGroupIds:
           - Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SecurityGroup"
         Subnets:


### PR DESCRIPTION
I manually specify which instances we want because otherwise, when requesting 4 CPUs to be always available it would  use instance 2x`r6i.large` which as 2CPU & 16GB memory each. This is not desirable because for the time being we will be requesting 32GB for each pipeline until we fine-tune memory consumption. This means, that we would have 2 machines with 16GB and whenever a new pipeline arrives (requesting 32GB) it would need to spin up a new node `r6i.xlarge` (with 32GB of memory)

# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2218

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR