### PR TITLE
[BIOMAGE-2268] - Add self-signed cert option

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -282,7 +282,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      - id: is-self-signed-certificate
+      - id: using-self-signed-certificate
         name: Get config for whether deployment is using self-signed certificate
         uses: mikefarah/yq@master
         with:
@@ -316,7 +316,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
           DOMAIN_NAME: ${{ steps.setup-domain.outputs.domain-name }}
           ACM_CERTIFICATE_ARN: ${{ secrets.ACM_CERTIFICATE_ARN }}
-          SELF_SIGNED_CERTIFICATE: ${{ steps.is-self-signed-certificate.outputs.result }}
+          SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
           MONITORING_ENABLED: ${{ steps.platform-monitoring-enabled.outputs.result }}
 
       - id: create-account-information-configmap

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -282,6 +282,14 @@ jobs:
         env:
           ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
+      - id: is-self-signed-certificate
+        name: Get config for whether deployment is using self-signed certificate
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.[env(ENVIRONMENT_NAME)].selfSignedCertificate' 'infra/config/github-environments-config.yaml'
+        env:
+          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+
       - id: fill-account-specific-metadata
         name: Fill in account specific metadata in ConfigMap
         run: |-
@@ -290,6 +298,7 @@ jobs:
             .myAccount.region = strenv(AWS_REGION) |
             .myAccount.accountId = strenv(AWS_ACCOUNT_ID) |
             .myAccount.acmCertificate = strenv(ACM_CERTIFICATE_ARN) |
+            .myAccount.selfSignedCertificate = strenv(SELF_SIGNED_CERTIFICATE) |
             .myAccount.datadogEnabled = strenv(MONITORING_ENABLED) |
             .myAccount.datadogApiKey = ""
           ' infra/config/account-config.yaml
@@ -307,6 +316,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
           DOMAIN_NAME: ${{ steps.setup-domain.outputs.domain-name }}
           ACM_CERTIFICATE_ARN: ${{ secrets.ACM_CERTIFICATE_ARN }}
+          SELF_SIGNED_CERTIFICATE: ${{ steps.is-self-signed-certificate.outputs.result }}
           MONITORING_ENABLED: ${{ steps.platform-monitoring-enabled.outputs.result }}
 
       - id: create-account-information-configmap

--- a/charts/nodejs/templates/deployment.yaml
+++ b/charts/nodejs/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
         - name: DOMAIN_NAME
           value: {{ .Values.myAccount.domainName | quote }}
 
+{{- if eq .Values.myAccount.selfSignedCertificate "true" }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value:  "0"
+{{- end }}
+
         ports:
         - name: "{{ .Values.service.name }}"
           containerPort: {{ .Values.service.internalPort }}

--- a/infra/config/account-config.yaml
+++ b/infra/config/account-config.yaml
@@ -4,6 +4,7 @@ myAccount:
   region: FILLED_IN_BY_CI
   accountId: FILLED_IN_BY_CI
   acmCertificate: FILLED_IN_BY_CI
+  selfSignedCertificate: FILLED_IN_BY_CI
   datadogEnabled: FILLED_IN_BY_CI
   datadogApiKey: FILLED_IN_BY_CI
   #FILLED IN BY IAC CI

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -2,7 +2,9 @@ Biomage:
   fluxGitReadOnly: false
   publicFacing: true
   monitoringEnabled: true
+  selfSignedCertificate: false
 trv:
   fluxGitReadOnly: true
   publicFacing: false
   monitoringEnabled: false
+  selfSignedCertificate: true


### PR DESCRIPTION
# Background
Adds a way to persist the option for NodeJS to allow connections to self-signed certificate endpoints.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2268

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR