### PR TITLE
Enable monitoring in other deployments

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -106,6 +106,11 @@ jobs:
             echo Secret DOMAIN_NAME is not set in repository secrets. Make sure this secret exists in the repository secrets.
             ERROR=true
           fi
+          if [ -z "${{ secrets.DATADOG_API_KEY }}" ]
+          then
+            echo Secret DATADOG_API_KEY is not set in repository secrets. Make sure this secret exists in the repository secrets.
+            ERROR=true
+          fi
           if [ ! -z "$ERROR" ]
           then
             echo
@@ -441,14 +446,6 @@ jobs:
       ###
       ### INSTALL AND CONFIGURE FLUX V2 ###
       ###
-      - id: platform-monitoring-enabled
-        name: Get config for whether monitoring should be enabled for deployment
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.[env(ENVIRONMENT_NAME)].monitoringEnabled' 'infra/config/github-environments-config.yaml'
-        env:
-          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
-
       - id: using-self-signed-certificate
         name: Get config for whether deployment is using self-signed certificate
         uses: mikefarah/yq@master
@@ -460,6 +457,8 @@ jobs:
       - id: fill-account-specific-metadata
         name: Fill in account specific metadata in ConfigMap
         run: |-
+          export DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
+
           yq -i '
             .myAccount.domainName = strenv(DOMAIN_NAME) |
             .myAccount.region = strenv(AWS_REGION) |
@@ -467,21 +466,16 @@ jobs:
             .myAccount.publicFacing = strenv(PUBLIC_FACING) |
             .myAccount.acmCertificate = strenv(ACM_CERTIFICATE_ARN) |
             .myAccount.selfSignedCertificate = strenv(SELF_SIGNED_CERTIFICATE) |
-            .myAccount.datadogEnabled = strenv(MONITORING_ENABLED) |
-            .myAccount.datadogApiKey = ""
+            .myAccount.datadogEnabled = "true" |
+            .myAccount.datadogApiKey = strenv(DATADOG_API_KEY)
           ' infra/config/account-config.yaml
-          if [[ $MONITORING_ENABLED = "true" ]]
-          then
-            export API_KEY="${{ secrets.DATADOG_API_KEY }}"
-            yq -i '.myAccount.datadogApiKey = strenv(API_KEY)' infra/config/account-config.yaml
-          fi
+
           cat infra/config/account-config.yaml
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
           DOMAIN_NAME: ${{ steps.setup-domain.outputs.domain-name }}
           ACM_CERTIFICATE_ARN: ${{ secrets.ACM_CERTIFICATE_ARN }}
-          MONITORING_ENABLED: ${{ steps.platform-monitoring-enabled.outputs.result }}
           PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
           SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
 

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -238,221 +238,221 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: deploy-metrics-server
-        name: Deploy k8s metrics server
-        run: |-
-          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+      # - id: deploy-metrics-server
+      #   name: Deploy k8s metrics server
+      #   run: |-
+      #     kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 
-      - id: install-helm
-        name: Install Helm
-        run: |-
-          sudo snap install helm --classic
+      # - id: install-helm
+      #   name: Install Helm
+      #   run: |-
+      #     sudo snap install helm --classic
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: deploy-load-balancer-role
-        name: Deploy permissions for AWS load balancer controller
-        run: |-
-          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
-          aws iam create-policy \
-            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --policy-document file://iam-policy.json || true
-          eksctl create iamserviceaccount \
-            --cluster=biomage-$CLUSTER_ENV \
-            --namespace=kube-system \
-            --name=aws-load-balancer-controller \
-            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --override-existing-serviceaccounts \
-            --approve
+      # - id: deploy-load-balancer-role
+      #   name: Deploy permissions for AWS load balancer controller
+      #   run: |-
+      #     curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+      #     aws iam create-policy \
+      #       --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+      #       --policy-document file://iam-policy.json || true
+      #     eksctl create iamserviceaccount \
+      #       --cluster=biomage-$CLUSTER_ENV \
+      #       --namespace=kube-system \
+      #       --name=aws-load-balancer-controller \
+      #       --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+      #       --override-existing-serviceaccounts \
+      #       --approve
 
-      # we need to retry this due to an active issue with the AWS Load Balancer Controller
-      # where there are intermittent failures that are only fixable by retrying
-      # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
-      - id: install-lbc
-        name: Deploy AWS Load Balancer Controller
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 600
-          max_attempts: 20
-          retry_on: error
-          on_retry_command: sleep $(shuf -i 5-15 -n 1)
-          command: |-
-            helm repo add eks https://aws.github.io/eks-charts
-            kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
-            helm repo update
-            helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
-              --namespace kube-system \
-              --set serviceAccount.create=false \
-              --set serviceAccount.name=aws-load-balancer-controller \
-              --set clusterName=biomage-$CLUSTER_ENV \
-              --install --wait
+      # # we need to retry this due to an active issue with the AWS Load Balancer Controller
+      # # where there are intermittent failures that are only fixable by retrying
+      # # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
+      # - id: install-lbc
+      #   name: Deploy AWS Load Balancer Controller
+      #   uses: nick-invision/retry@v2
+      #   with:
+      #     timeout_seconds: 600
+      #     max_attempts: 20
+      #     retry_on: error
+      #     on_retry_command: sleep $(shuf -i 5-15 -n 1)
+      #     command: |-
+      #       helm repo add eks https://aws.github.io/eks-charts
+      #       kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+      #       helm repo update
+      #       helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+      #         --namespace kube-system \
+      #         --set serviceAccount.create=false \
+      #         --set serviceAccount.name=aws-load-balancer-controller \
+      #         --set clusterName=biomage-$CLUSTER_ENV \
+      #         --install --wait
 
-      - id: platform-public-facing
-        name: Get config for whether platform should be public facing
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.[env(ENVIRONMENT_NAME)].publicFacing' 'infra/config/github-environments-config.yaml'
-        env:
-          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+      # - id: platform-public-facing
+      #   name: Get config for whether platform should be public facing
+      #   uses: mikefarah/yq@master
+      #   with:
+      #     cmd: yq '.[env(ENVIRONMENT_NAME)].publicFacing' 'infra/config/github-environments-config.yaml'
+      #   env:
+      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      - id: install-elb-503-subscription-endpoint
-        name: Install ELB 503 subscription endpoint
-        run: |-
-            echo "value of publicFacing: $PUBLIC_FACING"
+      # - id: install-elb-503-subscription-endpoint
+      #   name: Install ELB 503 subscription endpoint
+      #   run: |-
+      #       echo "value of publicFacing: $PUBLIC_FACING"
 
-            # Check that publicFacing is set to true or false
-            if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
-              echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
-              exit 1
-            fi
+      #       # Check that publicFacing is set to true or false
+      #       if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
+      #         echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
+      #         exit 1
+      #       fi
 
-            # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
-            # API staging environments because their endpoints are not yet available.
-            helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
-              --namespace default \
-              --set clusterEnv=$CLUSTER_ENV \
-              --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
-              --set-string publicFacing="$PUBLIC_FACING" \
-              --install --wait
-        env:
-          PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
+      #       # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
+      #       # API staging environments because their endpoints are not yet available.
+      #       helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
+      #         --namespace default \
+      #         --set clusterEnv=$CLUSTER_ENV \
+      #         --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
+      #         --set-string publicFacing="$PUBLIC_FACING" \
+      #         --install --wait
+      #   env:
+      #     PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
 
-      - id: deploy-env-loadbalancer
-        name: Deploy AWS Application Load Balancer for environment
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
-          name: "biomage-k8s-alb-${{ matrix.environment-type }}"
-          template: 'infra/cf-loadbalancer.yaml'
-          no-fail-on-empty-changeset: "1"
-
-      - id: setup-domain
-        name: Compile environment-specific domain name
-        run: |-
-          if [ "${{ matrix.environment-type }}" = "production" ]; then
-            PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
-            DOMAIN_NAME="${{ secrets.DOMAIN_NAME }}"
-          fi
-          if [ "${{ matrix.environment-type }}" = "staging" ]; then
-            PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
-            DOMAIN_NAME="${{ secrets.DOMAIN_NAME_STAGING }}"
-          fi
-          echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
-          echo "::set-output name=domain-name::$DOMAIN_NAME"
-
-      # This is commented out because running Route53 for trv is still causing an error.
-      # A ticket to address this issue has been made: BIOMAGE-2314. Refer to the ticket for more information.
-      # - id: deploy-route53
-      #   name: Deploy Route 53 DNS records to ELB
+      # - id: deploy-env-loadbalancer
+      #   name: Deploy AWS Application Load Balancer for environment
       #   uses: aws-actions/aws-cloudformation-github-deploy@v1
       #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }},DNSName=${{ steps.deploy-env-loadbalancer.outputs.DNSName }},HostedZoneId=${{ steps.deploy-env-loadbalancer.outputs.CanonicalHostedZoneID }},PrimaryDomainName=${{ steps.setup-domain.outputs.primary-domain-name }},DomainName=${{ steps.setup-domain.outputs.domain-name }}"
-      #     name: "biomage-alb-route53-${{ matrix.environment-type }}"
-      #     template: 'infra/cf-route53.yaml'
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
+      #     name: "biomage-k8s-alb-${{ matrix.environment-type }}"
+      #     template: 'infra/cf-loadbalancer.yaml'
       #     no-fail-on-empty-changeset: "1"
 
-      - id: deploy-xray-daemon
-        name: Deploy AWS X-Ray daemon
-        run: |-
-          helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
-            --namespace default \
-            --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
-            --install --wait
+      # - id: setup-domain
+      #   name: Compile environment-specific domain name
+      #   run: |-
+      #     if [ "${{ matrix.environment-type }}" = "production" ]; then
+      #       PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
+      #       DOMAIN_NAME="${{ secrets.DOMAIN_NAME }}"
+      #     fi
+      #     if [ "${{ matrix.environment-type }}" = "staging" ]; then
+      #       PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
+      #       DOMAIN_NAME="${{ secrets.DOMAIN_NAME_STAGING }}"
+      #     fi
+      #     echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
+      #     echo "::set-output name=domain-name::$DOMAIN_NAME"
 
-      - id: install-ebs-csi-driver
-        name: Install AWS EBS Container Storage Interface (CSI) drivers
-        run: |-
-          helm upgrade \
-            aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
-            --namespace kube-system \
-            --set enableVolumeScheduling=true \
-            --set enableVolumeResizing=true \
-            --set enableVolumeSnapshot=true \
-            --install --wait \
+      # # This is commented out because running Route53 for trv is still causing an error.
+      # # A ticket to address this issue has been made: BIOMAGE-2314. Refer to the ticket for more information.
+      # # - id: deploy-route53
+      # #   name: Deploy Route 53 DNS records to ELB
+      # #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      # #   with:
+      # #     parameter-overrides: "Environment=${{ matrix.environment-type }},DNSName=${{ steps.deploy-env-loadbalancer.outputs.DNSName }},HostedZoneId=${{ steps.deploy-env-loadbalancer.outputs.CanonicalHostedZoneID }},PrimaryDomainName=${{ steps.setup-domain.outputs.primary-domain-name }},DomainName=${{ steps.setup-domain.outputs.domain-name }}"
+      # #     name: "biomage-alb-route53-${{ matrix.environment-type }}"
+      # #     template: 'infra/cf-route53.yaml'
+      # #     no-fail-on-empty-changeset: "1"
 
-      - id: deploy-read-only-group
-        name: Deploy read-only permission definition for cluster
-        run: |-
-          helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
-            --install --wait
+      # - id: deploy-xray-daemon
+      #   name: Deploy AWS X-Ray daemon
+      #   run: |-
+      #     helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
+      #       --namespace default \
+      #       --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
+      #       --install --wait
 
-      - id: deploy-state-machine-role
-        name: Deploy AWS Step Function (state machine) roles
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }}"
-          name: "biomage-state-machine-role-${{ matrix.environment-type }}"
-          template: 'infra/cf-state-machine-role.yaml'
-          capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
-          no-fail-on-empty-changeset: "1"
+      # - id: install-ebs-csi-driver
+      #   name: Install AWS EBS Container Storage Interface (CSI) drivers
+      #   run: |-
+      #     helm upgrade \
+      #       aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
+      #       --namespace kube-system \
+      #       --set enableVolumeScheduling=true \
+      #       --set enableVolumeResizing=true \
+      #       --set enableVolumeSnapshot=true \
+      #       --install --wait \
 
-      - id: remove-identitymappings
-        name: Remove all previous identity mappings for IAM users
-        run: |-
-          eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
-          jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
-          while IFS= read -r user
-          do
-            echo "Remove rights of $user"
-            eksctl delete iamidentitymapping \
-              --cluster=biomage-$CLUSTER_ENV \
-              --arn $user \
-              --all
-          done < "/tmp/users_to_remove"
+      # - id: deploy-read-only-group
+      #   name: Deploy read-only permission definition for cluster
+      #   run: |-
+      #     helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
+      #       --install --wait
 
-      # see https://eksctl.io/usage/iam-identity-mappings/
-      - id: add-state-machine-role
-        name: Grant rights to the state machine IAM role.
-        run: |-
-          eksctl create iamidentitymapping \
-            --cluster=biomage-$CLUSTER_ENV \
-            --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
-            --group state-machine-runner-group \
-            --username state-machine-runner
+      # - id: deploy-state-machine-role
+      #   name: Deploy AWS Step Function (state machine) roles
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
+      #     name: "biomage-state-machine-role-${{ matrix.environment-type }}"
+      #     template: 'infra/cf-state-machine-role.yaml'
+      #     capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
+      #     no-fail-on-empty-changeset: "1"
 
-      # see https://eksctl.io/usage/iam-identity-mappings/
-      # NOTE: after updating this step, make sure you apply the updates in other relevant Github Actions workflows
-      - id: update-identitymapping-admin
-        name: Add cluster admin rights to everyone on the admin list.
-        run: |-
-          echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
-          while IFS= read -r user
-          do
-            echo "Adding cluster admin rights to $user"
-            eksctl create iamidentitymapping \
-              --cluster=biomage-$CLUSTER_ENV \
-              --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
-              --group system:masters \
-              --username $user
-          done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+      # - id: remove-identitymappings
+      #   name: Remove all previous identity mappings for IAM users
+      #   run: |-
+      #     eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
+      #     jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
+      #     while IFS= read -r user
+      #     do
+      #       echo "Remove rights of $user"
+      #       eksctl delete iamidentitymapping \
+      #         --cluster=biomage-$CLUSTER_ENV \
+      #         --arn $user \
+      #         --all
+      #     done < "/tmp/users_to_remove"
 
-      ###
-      ### INSTALL AND CONFIGURE FLUX V2 ###
-      ###
-      - id: using-self-signed-certificate
-        name: Get config for whether deployment is using self-signed certificate
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.[env(ENVIRONMENT_NAME)].selfSignedCertificate' 'infra/config/github-environments-config.yaml'
-        env:
-          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+      # # see https://eksctl.io/usage/iam-identity-mappings/
+      # - id: add-state-machine-role
+      #   name: Grant rights to the state machine IAM role.
+      #   run: |-
+      #     eksctl create iamidentitymapping \
+      #       --cluster=biomage-$CLUSTER_ENV \
+      #       --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
+      #       --group state-machine-runner-group \
+      #       --username state-machine-runner
+
+      # # see https://eksctl.io/usage/iam-identity-mappings/
+      # # NOTE: after updating this step, make sure you apply the updates in other relevant Github Actions workflows
+      # - id: update-identitymapping-admin
+      #   name: Add cluster admin rights to everyone on the admin list.
+      #   run: |-
+      #     echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+      #     while IFS= read -r user
+      #     do
+      #       echo "Adding cluster admin rights to $user"
+      #       eksctl create iamidentitymapping \
+      #         --cluster=biomage-$CLUSTER_ENV \
+      #         --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
+      #         --group system:masters \
+      #         --username $user
+      #     done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+
+      # ###
+      # ### INSTALL AND CONFIGURE FLUX V2 ###
+      # ###
+      # - id: using-self-signed-certificate
+      #   name: Get config for whether deployment is using self-signed certificate
+      #   uses: mikefarah/yq@master
+      #   with:
+      #     cmd: yq '.[env(ENVIRONMENT_NAME)].selfSignedCertificate' 'infra/config/github-environments-config.yaml'
+      #   env:
+      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
       - id: fill-account-specific-metadata
         name: Fill in account specific metadata in ConfigMap
@@ -479,120 +479,120 @@ jobs:
           PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
           SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
 
-      - id: create-flux-namespace
-        name: Attempt to create flux namespace
-        continue-on-error: true
-        run: |-
-          kubectl create namespace flux-system
+      # - id: create-flux-namespace
+      #   name: Attempt to create flux namespace
+      #   continue-on-error: true
+      #   run: |-
+      #     kubectl create namespace flux-system
 
-      - id: create-account-information-configmap
-        name: Create a configmap containing AWS account specific details
-        continue-on-error: false
-        run: |-
-          kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
+      # - id: create-account-information-configmap
+      #   name: Create a configmap containing AWS account specific details
+      #   continue-on-error: false
+      #   run: |-
+      #     kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
 
-      - id: install-flux-v2
-        name: Install flux CLI
-        run: |-
-          curl -s https://fluxcd.io/install.sh | sudo bash
+      # - id: install-flux-v2
+      #   name: Install flux CLI
+      #   run: |-
+      #     curl -s https://fluxcd.io/install.sh | sudo bash
 
-      - id: delete-old-flux-github-deploy-key
-        name: Attempt to delete previous github flux deploy key
-        continue-on-error: true
-        run: |-
-          kubectl -n flux-system delete secret flux-system
+      # - id: delete-old-flux-github-deploy-key
+      #   name: Attempt to delete previous github flux deploy key
+      #   continue-on-error: true
+      #   run: |-
+      #     kubectl -n flux-system delete secret flux-system
 
-      - id: install-flux
-        name: Install Flux to EKS cluster
-        run: |-
+      # - id: install-flux
+      #   name: Install Flux to EKS cluster
+      #   run: |-
 
-          FLUX_REPO=releases
-          FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
-          REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
+      #     FLUX_REPO=releases
+      #     FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
+      #     REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
 
-          echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
-          echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
+      #     echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
+      #     echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
 
-          args=(
-            --owner $GITHUB_REPOSITORY_OWNER
-            --repository $FLUX_REPO
-            --branch master
-            --path $FLUX_PATH
-            --timeout 40s
-            –-interval 2m
-            --components-extra=image-reflector-controller,image-automation-controller
-            --namespace flux-system
-            --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-            --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-          )
+      #     args=(
+      #       --owner $GITHUB_REPOSITORY_OWNER
+      #       --repository $FLUX_REPO
+      #       --branch master
+      #       --path $FLUX_PATH
+      #       --timeout 40s
+      #       –-interval 2m
+      #       --components-extra=image-reflector-controller,image-automation-controller
+      #       --namespace flux-system
+      #       --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+      #       --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+      #     )
           
-          if [ "${{ matrix.environment-type }}" = "staging" ]
-          then
-            echo Flux will be deployed in staging with read and write permissions
-            args+=(--read-write-key)
-          elif [ "${{ matrix.environment-type }}" = "production" ]
-          then
-            echo Flux will be deployed in production with read-only permissions
-          fi
+      #     if [ "${{ matrix.environment-type }}" = "staging" ]
+      #     then
+      #       echo Flux will be deployed in staging with read and write permissions
+      #       args+=(--read-write-key)
+      #     elif [ "${{ matrix.environment-type }}" = "production" ]
+      #     then
+      #       echo Flux will be deployed in production with read-only permissions
+      #     fi
           
-          flux bootstrap github "${args[@]}"
+      #     flux bootstrap github "${args[@]}"
 
-        env:
-          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
-          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #     AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
+      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      - id: fill-in-sync-yaml
-        name: Create the sync.yaml file that contains the Kustomization to sync the cluster
-        run: |-
-          export SPEC_PATH="./$CLUSTER_ENV"
-          yq -i '
-            .spec.path = strenv(SPEC_PATH)
-          ' infra/flux/sync.yaml
+      # - id: fill-in-sync-yaml
+      #   name: Create the sync.yaml file that contains the Kustomization to sync the cluster
+      #   run: |-
+      #     export SPEC_PATH="./$CLUSTER_ENV"
+      #     yq -i '
+      #       .spec.path = strenv(SPEC_PATH)
+      #     ' infra/flux/sync.yaml
 
-          cat infra/flux/sync.yaml
+      #     cat infra/flux/sync.yaml
 
-      - id: push-sync-yaml
-        name: Push the sync.yaml file that was filled in during the previous step
-        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source_file: infra/flux/sync.yaml
-          destination_repo: ${{ env.flux-full-repo }}
-          destination_folder: ${{ env.flux-path }}
-          user_email: ci@biomage.net
-          user_name: 'Biomage CI/CD'
+      # - id: push-sync-yaml
+      #   name: Push the sync.yaml file that was filled in during the previous step
+      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #   with:
+      #     source_file: infra/flux/sync.yaml
+      #     destination_repo: ${{ env.flux-full-repo }}
+      #     destination_folder: ${{ env.flux-path }}
+      #     user_email: ci@biomage.net
+      #     user_name: 'Biomage CI/CD'
 
-      - id: push-kustomization-yaml
-        name: Push the kustomization.yaml file to apply our custom config
-        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source_file: infra/flux/kustomization.yaml
-          destination_repo: ${{ env.flux-full-repo }}
-          destination_folder: ${{ env.flux-path }}/flux-system
-          user_email: ci@biomage.net
-          user_name: 'Biomage CI/CD'
+      # - id: push-kustomization-yaml
+      #   name: Push the kustomization.yaml file to apply our custom config
+      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #   with:
+      #     source_file: infra/flux/kustomization.yaml
+      #     destination_repo: ${{ env.flux-full-repo }}
+      #     destination_folder: ${{ env.flux-path }}/flux-system
+      #     user_email: ci@biomage.net
+      #     user_name: 'Biomage CI/CD'
 
-      - id: install-kubernetes-reflector
-        name: Install kubernetes reflector
-        run: |-
-          helm repo add emberstack https://emberstack.github.io/helm-charts
-          helm repo update
-          helm upgrade --install reflector emberstack/reflector --namespace flux-system
+      # - id: install-kubernetes-reflector
+      #   name: Install kubernetes reflector
+      #   run: |-
+      #     helm repo add emberstack https://emberstack.github.io/helm-charts
+      #     helm repo update
+      #     helm upgrade --install reflector emberstack/reflector --namespace flux-system
 
-      - id: add-account-config-configmap-annotations
-        name: Add annotations to account-config configmap
-        run: |-
-          kubectl annotate configmap account-config \
-            --overwrite \
-            --namespace flux-system \
-            reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
-            reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
-            reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
+      # - id: add-account-config-configmap-annotations
+      #   name: Add annotations to account-config configmap
+      #   run: |-
+      #     kubectl annotate configmap account-config \
+      #       --overwrite \
+      #       --namespace flux-system \
+      #       reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+      #       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
+      #       reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
       ###
       ### END OF INSTALL AND CONFIGURE FLUX V2 ###
       ###

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -238,13 +238,13 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      # - id: setup-aws
-      #   name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_REGION }}
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       # - id: add-kubeconfig
       #   name: Add k8s config file for existing cluster.
@@ -304,13 +304,13 @@ jobs:
       #         --set clusterName=biomage-$CLUSTER_ENV \
       #         --install --wait
 
-      # - id: platform-public-facing
-      #   name: Get config for whether platform should be public facing
-      #   uses: mikefarah/yq@master
-      #   with:
-      #     cmd: yq '.[env(ENVIRONMENT_NAME)].publicFacing' 'infra/config/github-environments-config.yaml'
-      #   env:
-      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+      - id: platform-public-facing
+        name: Get config for whether platform should be public facing
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.[env(ENVIRONMENT_NAME)].publicFacing' 'infra/config/github-environments-config.yaml'
+        env:
+          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
       # - id: install-elb-503-subscription-endpoint
       #   name: Install ELB 503 subscription endpoint
@@ -343,19 +343,19 @@ jobs:
       #     template: 'infra/cf-loadbalancer.yaml'
       #     no-fail-on-empty-changeset: "1"
 
-      # - id: setup-domain
-      #   name: Compile environment-specific domain name
-      #   run: |-
-      #     if [ "${{ matrix.environment-type }}" = "production" ]; then
-      #       PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
-      #       DOMAIN_NAME="${{ secrets.DOMAIN_NAME }}"
-      #     fi
-      #     if [ "${{ matrix.environment-type }}" = "staging" ]; then
-      #       PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
-      #       DOMAIN_NAME="${{ secrets.DOMAIN_NAME_STAGING }}"
-      #     fi
-      #     echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
-      #     echo "::set-output name=domain-name::$DOMAIN_NAME"
+      - id: setup-domain
+        name: Compile environment-specific domain name
+        run: |-
+          if [ "${{ matrix.environment-type }}" = "production" ]; then
+            PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
+            DOMAIN_NAME="${{ secrets.DOMAIN_NAME }}"
+          fi
+          if [ "${{ matrix.environment-type }}" = "staging" ]; then
+            PRIMARY_DOMAIN_NAME="${{ secrets.PRIMARY_DOMAIN_NAME }}"
+            DOMAIN_NAME="${{ secrets.DOMAIN_NAME_STAGING }}"
+          fi
+          echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
+          echo "::set-output name=domain-name::$DOMAIN_NAME"
 
       # # This is commented out because running Route53 for trv is still causing an error.
       # # A ticket to address this issue has been made: BIOMAGE-2314. Refer to the ticket for more information.
@@ -443,16 +443,16 @@ jobs:
       #         --username $user
       #     done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
 
-      # ###
-      # ### INSTALL AND CONFIGURE FLUX V2 ###
-      # ###
-      # - id: using-self-signed-certificate
-      #   name: Get config for whether deployment is using self-signed certificate
-      #   uses: mikefarah/yq@master
-      #   with:
-      #     cmd: yq '.[env(ENVIRONMENT_NAME)].selfSignedCertificate' 'infra/config/github-environments-config.yaml'
-      #   env:
-      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+      ###
+      ### INSTALL AND CONFIGURE FLUX V2 ###
+      ###
+      - id: using-self-signed-certificate
+        name: Get config for whether deployment is using self-signed certificate
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.[env(ENVIRONMENT_NAME)].selfSignedCertificate' 'infra/config/github-environments-config.yaml'
+        env:
+          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
       - id: fill-account-specific-metadata
         name: Fill in account specific metadata in ConfigMap

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -246,63 +246,63 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # - id: deploy-metrics-server
-      #   name: Deploy k8s metrics server
-      #   run: |-
-      #     kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+      - id: deploy-metrics-server
+        name: Deploy k8s metrics server
+        run: |-
+          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 
-      # - id: install-helm
-      #   name: Install Helm
-      #   run: |-
-      #     sudo snap install helm --classic
+      - id: install-helm
+        name: Install Helm
+        run: |-
+          sudo snap install helm --classic
 
-      # - id: install-eksctl
-      #   name: Install eksctl
-      #   run: |-
-      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-      #     sudo mv /tmp/eksctl /usr/local/bin
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
 
-      # - id: deploy-load-balancer-role
-      #   name: Deploy permissions for AWS load balancer controller
-      #   run: |-
-      #     curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
-      #     aws iam create-policy \
-      #       --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-      #       --policy-document file://iam-policy.json || true
-      #     eksctl create iamserviceaccount \
-      #       --cluster=biomage-$CLUSTER_ENV \
-      #       --namespace=kube-system \
-      #       --name=aws-load-balancer-controller \
-      #       --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-      #       --override-existing-serviceaccounts \
-      #       --approve
+      - id: deploy-load-balancer-role
+        name: Deploy permissions for AWS load balancer controller
+        run: |-
+          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+          aws iam create-policy \
+            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --policy-document file://iam-policy.json || true
+          eksctl create iamserviceaccount \
+            --cluster=biomage-$CLUSTER_ENV \
+            --namespace=kube-system \
+            --name=aws-load-balancer-controller \
+            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --override-existing-serviceaccounts \
+            --approve
 
-      # # we need to retry this due to an active issue with the AWS Load Balancer Controller
-      # # where there are intermittent failures that are only fixable by retrying
-      # # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
-      # - id: install-lbc
-      #   name: Deploy AWS Load Balancer Controller
-      #   uses: nick-invision/retry@v2
-      #   with:
-      #     timeout_seconds: 600
-      #     max_attempts: 20
-      #     retry_on: error
-      #     on_retry_command: sleep $(shuf -i 5-15 -n 1)
-      #     command: |-
-      #       helm repo add eks https://aws.github.io/eks-charts
-      #       kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
-      #       helm repo update
-      #       helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
-      #         --namespace kube-system \
-      #         --set serviceAccount.create=false \
-      #         --set serviceAccount.name=aws-load-balancer-controller \
-      #         --set clusterName=biomage-$CLUSTER_ENV \
-      #         --install --wait
+      # we need to retry this due to an active issue with the AWS Load Balancer Controller
+      # where there are intermittent failures that are only fixable by retrying
+      # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
+      - id: install-lbc
+        name: Deploy AWS Load Balancer Controller
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 600
+          max_attempts: 20
+          retry_on: error
+          on_retry_command: sleep $(shuf -i 5-15 -n 1)
+          command: |-
+            helm repo add eks https://aws.github.io/eks-charts
+            kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+            helm repo update
+            helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+              --namespace kube-system \
+              --set serviceAccount.create=false \
+              --set serviceAccount.name=aws-load-balancer-controller \
+              --set clusterName=biomage-$CLUSTER_ENV \
+              --install --wait
 
       - id: platform-public-facing
         name: Get config for whether platform should be public facing
@@ -312,36 +312,36 @@ jobs:
         env:
           ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      # - id: install-elb-503-subscription-endpoint
-      #   name: Install ELB 503 subscription endpoint
-      #   run: |-
-      #       echo "value of publicFacing: $PUBLIC_FACING"
+      - id: install-elb-503-subscription-endpoint
+        name: Install ELB 503 subscription endpoint
+        run: |-
+            echo "value of publicFacing: $PUBLIC_FACING"
 
-      #       # Check that publicFacing is set to true or false
-      #       if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
-      #         echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
-      #         exit 1
-      #       fi
+            # Check that publicFacing is set to true or false
+            if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
+              echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
+              exit 1
+            fi
 
-      #       # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
-      #       # API staging environments because their endpoints are not yet available.
-      #       helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
-      #         --namespace default \
-      #         --set clusterEnv=$CLUSTER_ENV \
-      #         --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
-      #         --set-string publicFacing="$PUBLIC_FACING" \
-      #         --install --wait
-      #   env:
-      #     PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
+            # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
+            # API staging environments because their endpoints are not yet available.
+            helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
+              --namespace default \
+              --set clusterEnv=$CLUSTER_ENV \
+              --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
+              --set-string publicFacing="$PUBLIC_FACING" \
+              --install --wait
+        env:
+          PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
 
-      # - id: deploy-env-loadbalancer
-      #   name: Deploy AWS Application Load Balancer for environment
-      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
-      #     name: "biomage-k8s-alb-${{ matrix.environment-type }}"
-      #     template: 'infra/cf-loadbalancer.yaml'
-      #     no-fail-on-empty-changeset: "1"
+      - id: deploy-env-loadbalancer
+        name: Deploy AWS Application Load Balancer for environment
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
+          name: "biomage-k8s-alb-${{ matrix.environment-type }}"
+          template: 'infra/cf-loadbalancer.yaml'
+          no-fail-on-empty-changeset: "1"
 
       - id: setup-domain
         name: Compile environment-specific domain name
@@ -357,91 +357,91 @@ jobs:
           echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
           echo "::set-output name=domain-name::$DOMAIN_NAME"
 
-      # # This is commented out because running Route53 for trv is still causing an error.
-      # # A ticket to address this issue has been made: BIOMAGE-2314. Refer to the ticket for more information.
-      # # - id: deploy-route53
-      # #   name: Deploy Route 53 DNS records to ELB
-      # #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      # #   with:
-      # #     parameter-overrides: "Environment=${{ matrix.environment-type }},DNSName=${{ steps.deploy-env-loadbalancer.outputs.DNSName }},HostedZoneId=${{ steps.deploy-env-loadbalancer.outputs.CanonicalHostedZoneID }},PrimaryDomainName=${{ steps.setup-domain.outputs.primary-domain-name }},DomainName=${{ steps.setup-domain.outputs.domain-name }}"
-      # #     name: "biomage-alb-route53-${{ matrix.environment-type }}"
-      # #     template: 'infra/cf-route53.yaml'
-      # #     no-fail-on-empty-changeset: "1"
-
-      # - id: deploy-xray-daemon
-      #   name: Deploy AWS X-Ray daemon
-      #   run: |-
-      #     helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
-      #       --namespace default \
-      #       --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
-      #       --install --wait
-
-      # - id: install-ebs-csi-driver
-      #   name: Install AWS EBS Container Storage Interface (CSI) drivers
-      #   run: |-
-      #     helm upgrade \
-      #       aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
-      #       --namespace kube-system \
-      #       --set enableVolumeScheduling=true \
-      #       --set enableVolumeResizing=true \
-      #       --set enableVolumeSnapshot=true \
-      #       --install --wait \
-
-      # - id: deploy-read-only-group
-      #   name: Deploy read-only permission definition for cluster
-      #   run: |-
-      #     helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
-      #       --install --wait
-
-      # - id: deploy-state-machine-role
-      #   name: Deploy AWS Step Function (state machine) roles
+      # This is commented out because running Route53 for trv is still causing an error.
+      # A ticket to address this issue has been made: BIOMAGE-2314. Refer to the ticket for more information.
+      # - id: deploy-route53
+      #   name: Deploy Route 53 DNS records to ELB
       #   uses: aws-actions/aws-cloudformation-github-deploy@v1
       #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
-      #     name: "biomage-state-machine-role-${{ matrix.environment-type }}"
-      #     template: 'infra/cf-state-machine-role.yaml'
-      #     capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }},DNSName=${{ steps.deploy-env-loadbalancer.outputs.DNSName }},HostedZoneId=${{ steps.deploy-env-loadbalancer.outputs.CanonicalHostedZoneID }},PrimaryDomainName=${{ steps.setup-domain.outputs.primary-domain-name }},DomainName=${{ steps.setup-domain.outputs.domain-name }}"
+      #     name: "biomage-alb-route53-${{ matrix.environment-type }}"
+      #     template: 'infra/cf-route53.yaml'
       #     no-fail-on-empty-changeset: "1"
 
-      # - id: remove-identitymappings
-      #   name: Remove all previous identity mappings for IAM users
-      #   run: |-
-      #     eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
-      #     jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
-      #     while IFS= read -r user
-      #     do
-      #       echo "Remove rights of $user"
-      #       eksctl delete iamidentitymapping \
-      #         --cluster=biomage-$CLUSTER_ENV \
-      #         --arn $user \
-      #         --all
-      #     done < "/tmp/users_to_remove"
+      - id: deploy-xray-daemon
+        name: Deploy AWS X-Ray daemon
+        run: |-
+          helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
+            --namespace default \
+            --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
+            --install --wait
 
-      # # see https://eksctl.io/usage/iam-identity-mappings/
-      # - id: add-state-machine-role
-      #   name: Grant rights to the state machine IAM role.
-      #   run: |-
-      #     eksctl create iamidentitymapping \
-      #       --cluster=biomage-$CLUSTER_ENV \
-      #       --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
-      #       --group state-machine-runner-group \
-      #       --username state-machine-runner
+      - id: install-ebs-csi-driver
+        name: Install AWS EBS Container Storage Interface (CSI) drivers
+        run: |-
+          helm upgrade \
+            aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
+            --namespace kube-system \
+            --set enableVolumeScheduling=true \
+            --set enableVolumeResizing=true \
+            --set enableVolumeSnapshot=true \
+            --install --wait \
 
-      # # see https://eksctl.io/usage/iam-identity-mappings/
-      # # NOTE: after updating this step, make sure you apply the updates in other relevant Github Actions workflows
-      # - id: update-identitymapping-admin
-      #   name: Add cluster admin rights to everyone on the admin list.
-      #   run: |-
-      #     echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
-      #     while IFS= read -r user
-      #     do
-      #       echo "Adding cluster admin rights to $user"
-      #       eksctl create iamidentitymapping \
-      #         --cluster=biomage-$CLUSTER_ENV \
-      #         --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
-      #         --group system:masters \
-      #         --username $user
-      #     done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+      - id: deploy-read-only-group
+        name: Deploy read-only permission definition for cluster
+        run: |-
+          helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
+            --install --wait
+
+      - id: deploy-state-machine-role
+        name: Deploy AWS Step Function (state machine) roles
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }}"
+          name: "biomage-state-machine-role-${{ matrix.environment-type }}"
+          template: 'infra/cf-state-machine-role.yaml'
+          capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
+          no-fail-on-empty-changeset: "1"
+
+      - id: remove-identitymappings
+        name: Remove all previous identity mappings for IAM users
+        run: |-
+          eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
+          jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
+          while IFS= read -r user
+          do
+            echo "Remove rights of $user"
+            eksctl delete iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn $user \
+              --all
+          done < "/tmp/users_to_remove"
+
+      # see https://eksctl.io/usage/iam-identity-mappings/
+      - id: add-state-machine-role
+        name: Grant rights to the state machine IAM role.
+        run: |-
+          eksctl create iamidentitymapping \
+            --cluster=biomage-$CLUSTER_ENV \
+            --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
+            --group state-machine-runner-group \
+            --username state-machine-runner
+
+      # see https://eksctl.io/usage/iam-identity-mappings/
+      # NOTE: after updating this step, make sure you apply the updates in other relevant Github Actions workflows
+      - id: update-identitymapping-admin
+        name: Add cluster admin rights to everyone on the admin list.
+        run: |-
+          echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+          while IFS= read -r user
+          do
+            echo "Adding cluster admin rights to $user"
+            eksctl create iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
+              --group system:masters \
+              --username $user
+          done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
 
       ###
       ### INSTALL AND CONFIGURE FLUX V2 ###
@@ -479,120 +479,120 @@ jobs:
           PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
           SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
 
-      # - id: create-flux-namespace
-      #   name: Attempt to create flux namespace
-      #   continue-on-error: true
-      #   run: |-
-      #     kubectl create namespace flux-system
+      - id: create-flux-namespace
+        name: Attempt to create flux namespace
+        continue-on-error: true
+        run: |-
+          kubectl create namespace flux-system
 
-      # - id: create-account-information-configmap
-      #   name: Create a configmap containing AWS account specific details
-      #   continue-on-error: false
-      #   run: |-
-      #     kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
+      - id: create-account-information-configmap
+        name: Create a configmap containing AWS account specific details
+        continue-on-error: false
+        run: |-
+          kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
 
-      # - id: install-flux-v2
-      #   name: Install flux CLI
-      #   run: |-
-      #     curl -s https://fluxcd.io/install.sh | sudo bash
+      - id: install-flux-v2
+        name: Install flux CLI
+        run: |-
+          curl -s https://fluxcd.io/install.sh | sudo bash
 
-      # - id: delete-old-flux-github-deploy-key
-      #   name: Attempt to delete previous github flux deploy key
-      #   continue-on-error: true
-      #   run: |-
-      #     kubectl -n flux-system delete secret flux-system
+      - id: delete-old-flux-github-deploy-key
+        name: Attempt to delete previous github flux deploy key
+        continue-on-error: true
+        run: |-
+          kubectl -n flux-system delete secret flux-system
 
-      # - id: install-flux
-      #   name: Install Flux to EKS cluster
-      #   run: |-
+      - id: install-flux
+        name: Install Flux to EKS cluster
+        run: |-
 
-      #     FLUX_REPO=releases
-      #     FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
-      #     REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
+          FLUX_REPO=releases
+          FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
+          REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
 
-      #     echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
-      #     echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
+          echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
+          echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
 
-      #     args=(
-      #       --owner $GITHUB_REPOSITORY_OWNER
-      #       --repository $FLUX_REPO
-      #       --branch master
-      #       --path $FLUX_PATH
-      #       --timeout 40s
-      #       –-interval 2m
-      #       --components-extra=image-reflector-controller,image-automation-controller
-      #       --namespace flux-system
-      #       --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-      #       --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-      #     )
-          
-      #     if [ "${{ matrix.environment-type }}" = "staging" ]
-      #     then
-      #       echo Flux will be deployed in staging with read and write permissions
-      #       args+=(--read-write-key)
-      #     elif [ "${{ matrix.environment-type }}" = "production" ]
-      #     then
-      #       echo Flux will be deployed in production with read-only permissions
-      #     fi
-          
-      #     flux bootstrap github "${args[@]}"
+          args=(
+            --owner $GITHUB_REPOSITORY_OWNER
+            --repository $FLUX_REPO
+            --branch master
+            --path $FLUX_PATH
+            --timeout 40s
+            –-interval 2m
+            --components-extra=image-reflector-controller,image-automation-controller
+            --namespace flux-system
+            --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+            --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+          )
 
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #     AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
-      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+          if [ "${{ matrix.environment-type }}" = "staging" ]
+          then
+            echo Flux will be deployed in staging with read and write permissions
+            args+=(--read-write-key)
+          elif [ "${{ matrix.environment-type }}" = "production" ]
+          then
+            echo Flux will be deployed in production with read-only permissions
+          fi
 
-      # - id: fill-in-sync-yaml
-      #   name: Create the sync.yaml file that contains the Kustomization to sync the cluster
-      #   run: |-
-      #     export SPEC_PATH="./$CLUSTER_ENV"
-      #     yq -i '
-      #       .spec.path = strenv(SPEC_PATH)
-      #     ' infra/flux/sync.yaml
+          flux bootstrap github "${args[@]}"
 
-      #     cat infra/flux/sync.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
+          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      # - id: push-sync-yaml
-      #   name: Push the sync.yaml file that was filled in during the previous step
-      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #   with:
-      #     source_file: infra/flux/sync.yaml
-      #     destination_repo: ${{ env.flux-full-repo }}
-      #     destination_folder: ${{ env.flux-path }}
-      #     user_email: ci@biomage.net
-      #     user_name: 'Biomage CI/CD'
+      - id: fill-in-sync-yaml
+        name: Create the sync.yaml file that contains the Kustomization to sync the cluster
+        run: |-
+          export SPEC_PATH="./$CLUSTER_ENV"
+          yq -i '
+            .spec.path = strenv(SPEC_PATH)
+          ' infra/flux/sync.yaml
 
-      # - id: push-kustomization-yaml
-      #   name: Push the kustomization.yaml file to apply our custom config
-      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #   with:
-      #     source_file: infra/flux/kustomization.yaml
-      #     destination_repo: ${{ env.flux-full-repo }}
-      #     destination_folder: ${{ env.flux-path }}/flux-system
-      #     user_email: ci@biomage.net
-      #     user_name: 'Biomage CI/CD'
+          cat infra/flux/sync.yaml
 
-      # - id: install-kubernetes-reflector
-      #   name: Install kubernetes reflector
-      #   run: |-
-      #     helm repo add emberstack https://emberstack.github.io/helm-charts
-      #     helm repo update
-      #     helm upgrade --install reflector emberstack/reflector --namespace flux-system
+      - id: push-sync-yaml
+        name: Push the sync.yaml file that was filled in during the previous step
+        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: infra/flux/sync.yaml
+          destination_repo: ${{ env.flux-full-repo }}
+          destination_folder: ${{ env.flux-path }}
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'
 
-      # - id: add-account-config-configmap-annotations
-      #   name: Add annotations to account-config configmap
-      #   run: |-
-      #     kubectl annotate configmap account-config \
-      #       --overwrite \
-      #       --namespace flux-system \
-      #       reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
-      #       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
-      #       reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
+      - id: push-kustomization-yaml
+        name: Push the kustomization.yaml file to apply our custom config
+        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: infra/flux/kustomization.yaml
+          destination_repo: ${{ env.flux-full-repo }}
+          destination_folder: ${{ env.flux-path }}/flux-system
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'
+
+      - id: install-kubernetes-reflector
+        name: Install kubernetes reflector
+        run: |-
+          helm repo add emberstack https://emberstack.github.io/helm-charts
+          helm repo update
+          helm upgrade --install reflector emberstack/reflector --namespace flux-system
+
+      - id: add-account-config-configmap-annotations
+        name: Add annotations to account-config configmap
+        run: |-
+          kubectl annotate configmap account-config \
+            --overwrite \
+            --namespace flux-system \
+            reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+            reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
+            reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
       ###
       ### END OF INSTALL AND CONFIGURE FLUX V2 ###
       ###

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -441,11 +441,11 @@ jobs:
       ###
       ### INSTALL AND CONFIGURE FLUX V2 ###
       ###
-      - id: datadog-monitoring-enabled
+      - id: platform-monitoring-enabled
         name: Get config for whether monitoring should be enabled for deployment
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.[env(ENVIRONMENT_NAME)].datadogEnabled' 'infra/config/github-environments-config.yaml'
+          cmd: yq '.[env(ENVIRONMENT_NAME)].monitoringEnabled' 'infra/config/github-environments-config.yaml'
         env:
           ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
@@ -467,10 +467,10 @@ jobs:
             .myAccount.publicFacing = strenv(PUBLIC_FACING) |
             .myAccount.acmCertificate = strenv(ACM_CERTIFICATE_ARN) |
             .myAccount.selfSignedCertificate = strenv(SELF_SIGNED_CERTIFICATE) |
-            .myAccount.datadogEnabled = strenv(DATADOG_ENABLED) |
+            .myAccount.datadogEnabled = strenv(MONITORING_ENABLED) |
             .myAccount.datadogApiKey = ""
           ' infra/config/account-config.yaml
-          if [[ $DATADOG_ENABLED = "true" ]]
+          if [[ $MONITORING_ENABLED = "true" ]]
           then
             export API_KEY="${{ secrets.DATADOG_API_KEY }}"
             yq -i '.myAccount.datadogApiKey = strenv(API_KEY)' infra/config/account-config.yaml
@@ -481,7 +481,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
           DOMAIN_NAME: ${{ steps.setup-domain.outputs.domain-name }}
           ACM_CERTIFICATE_ARN: ${{ secrets.ACM_CERTIFICATE_ARN }}
-          DATADOG_ENABLED: ${{ steps.datadog-monitoring-enabled.outputs.result }}
+          MONITORING_ENABLED: ${{ steps.platform-monitoring-enabled.outputs.result }}
           PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
           SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
 

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -46,10 +46,10 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
-        environment-types: [production]
-      include:
-        - environment-name: Biomage
-          environment-type: staging
+        environment-type: [production]
+        include:
+          - environment-name: Biomage
+            environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
       - id: check-secrets

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -163,32 +163,32 @@ jobs:
 
       - id: test-if-statement-1
         name: Testing if statement Cloudwatch
-        if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
         run: |-
           echo "Running for Cloudwatch"
 
       - id: test-if-statement-2
-        if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
         name: Testing if statement Datadog
         run: |-
           echo "Running for Datadog"
 
       # - id: add-kubeconfig
       #   name: Add k8s config file for existing cluster.
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   run: |-
       #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
       # - id: install-eksctl
       #   name: Install eksctl
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   run: |-
       #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
       #     sudo mv /tmp/eksctl /usr/local/bin
 
       # - id: setup-cluster-cloudwatch-logging-policy
       #   name: Setup permissions required for cluster to log to Cloudwatch
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   uses: aws-actions/aws-cloudformation-github-deploy@v1
       #   with:
       #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
@@ -200,12 +200,12 @@ jobs:
       # # Setting up log forwarding for pods hosted in EC2 nodes
       # - id: create-fluent-bit-namespace
       #   name: Create namespace for node FluentBit deployment
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
       # - id: create-service-account-for-node-fluent-bit
       #   name: Create service account for node FluentBit
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
       #   run: |-
@@ -220,7 +220,7 @@ jobs:
 
       # - id: deploy-node-fluent-bit
       #   name: Deploy FluentBit for EC2 nodes
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     AWS_REGION: ${{ secrets.AWS_REGION }}
       #   run: |
@@ -235,7 +235,7 @@ jobs:
       # # Setting up log forwarding for pods hosted on Fargate nodes
       # - id: attach-pod-execution-role-name
       #   name: Attach logging policy to pod execution role
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
       #   run: |-
@@ -251,7 +251,7 @@ jobs:
 
       # - id: deploy-fargate-fluent-bit
       #   name: Deploy FluentBit config for Fargate pods
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     AWS_REGION: ${{ secrets.AWS_REGION }}
       #   run: |-
@@ -264,7 +264,7 @@ jobs:
       # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
       # - id: setup-datadog-cluster-agent
       #   name: Setup Datadog cluster agent
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
       #   run: |-
       #     helm repo add datadog https://helm.datadoghq.com
       #     helm repo update
@@ -276,7 +276,7 @@ jobs:
 
       # - id: setup-datadog-sidecar-permissions
       #   name: Setup Datadog sidecar permissions
-      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
       #   run: |-
       #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -20,13 +20,13 @@ jobs:
         uses: actions/checkout@v2
 
       - id: get-all-envs
-        name: Filter environments
+        name: Get all environments
         uses: mikefarah/yq@master
         with:
           cmd: yq 'keys' infra/config/github-environments-config.yaml -o json
 
       - id: get-datadog-enabled-envs
-        name: Filter environments
+        name: Get Datadog enabled envs
         uses: mikefarah/yq@master
         with:
           cmd: yq 'with_entries(select(.value.monitoringEnabled)) | keys' infra/config/github-environments-config.yaml -o json
@@ -98,93 +98,93 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: setup-cluster-cloudwatch-logging-policy
-        name: Setup permissions required for cluster to log to Cloudwatch
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }}"
-          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-          no-fail-on-empty-changeset: "1"
-          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+      # - id: setup-cluster-cloudwatch-logging-policy
+      #   name: Setup permissions required for cluster to log to Cloudwatch
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
+      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+      #     no-fail-on-empty-changeset: "1"
+      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      # Setting up log forwarding for pods hosted in EC2 nodes
-      - id: create-fluent-bit-namespace
-        name: Create namespace for node FluentBit deployment
-        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+      # # Setting up log forwarding for pods hosted in EC2 nodes
+      # - id: create-fluent-bit-namespace
+      #   name: Create namespace for node FluentBit deployment
+      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      - id: create-service-account-for-node-fluent-bit
-        name: Create service account for node FluentBit
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          eksctl create iamserviceaccount \
-            --name fluent-bit \
-            --namespace node-logging \
-            --cluster biomage-$CLUSTER_ENV \
-            --role-name irsa-fluent-bit-$CLUSTER_ENV \
-            --attach-policy-arn $LOGGING_POLICY_ARN \
-            --override-existing-serviceaccounts \
-            --approve
+      # - id: create-service-account-for-node-fluent-bit
+      #   name: Create service account for node FluentBit
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     eksctl create iamserviceaccount \
+      #       --name fluent-bit \
+      #       --namespace node-logging \
+      #       --cluster biomage-$CLUSTER_ENV \
+      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
+      #       --attach-policy-arn $LOGGING_POLICY_ARN \
+      #       --override-existing-serviceaccounts \
+      #       --approve
 
-      - id: deploy-node-fluent-bit
-        name: Deploy FluentBit for EC2 nodes
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |
-          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-          # We do not want to log everything for costs/security concerns
+      # - id: deploy-node-fluent-bit
+      #   name: Deploy FluentBit for EC2 nodes
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |
+      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+      #     # We do not want to log everything for costs/security concerns
 
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
-      # Setting up log forwarding for pods hosted on Fargate nodes
-      - id: attach-pod-execution-role-name
-        name: Attach logging policy to pod execution role
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+      # # Setting up log forwarding for pods hosted on Fargate nodes
+      # - id: attach-pod-execution-role-name
+      #   name: Attach logging policy to pod execution role
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-            --cluster-name biomage-$CLUSTER_ENV \
-            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+      #       --cluster-name biomage-$CLUSTER_ENV \
+      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      - id: deploy-fargate-fluent-bit
-        name: Deploy FluentBit config for Fargate pods
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |-
-          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      # - id: deploy-fargate-fluent-bit
+      #   name: Deploy FluentBit config for Fargate pods
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |-
+      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
   deploy-datadog-monitoring:
     name: Setup Datadog monitoring for deployment
@@ -227,35 +227,35 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      - id: setup-datadog-cluster-agent
-        name: Setup Datadog cluster agent
-        run: |-
-          helm repo add datadog https://helm.datadoghq.com
-          helm repo update
-          helm upgrade datadog-agent datadog/datadog \
-            -f infra/datadog/cluster-agent-values.yaml \
-            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-            --set datadog.clusterName=biomage-$CLUSTER_ENV \
-            --install
+      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      # - id: setup-datadog-cluster-agent
+      #   name: Setup Datadog cluster agent
+      #   run: |-
+      #     helm repo add datadog https://helm.datadoghq.com
+      #     helm repo update
+      #     helm upgrade datadog-agent datadog/datadog \
+      #       -f infra/datadog/cluster-agent-values.yaml \
+      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
+      #       --install
 
-      - id: setup-datadog-sidecar-permissions
-        name: Setup Datadog sidecar permissions
-        run: |-
-          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      # - id: setup-datadog-sidecar-permissions
+      #   name: Setup Datadog sidecar permissions
+      #   run: |-
+      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -11,7 +11,7 @@ on:
           - Biomage
           - all
         default: all
-      deployment_option:
+      monitoring_option:
         type: choice
         description: Select the monitoring to configure
         options:
@@ -114,7 +114,7 @@ jobs:
 
       - id: check-datadog-secrets
         name: Check if necessary Datadog secrets are installed.
-        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+        if: ${{ inputs.monitoring_option == 'all' || inputs.monitoring_option == 'Datadog' }}
         run: |-
           echo Checking if Datadog secrets are defined in the repository.
 
@@ -135,7 +135,7 @@ jobs:
   deploy-cloudwatch-monitoring:
     name: Setup Cloudwatch monitoring for deployment
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
+    if: ${{ inputs.monitoring_option == 'all' || inputs.monitoring_option == 'Cloudwatch' }}
     needs: [set-environments, check-secrets]
     env:
       CLUSTER_ENV: ${{ matrix.environment-type }}
@@ -245,7 +245,7 @@ jobs:
   deploy-datadog-monitoring:
     name: Setup Datadog monitoring for deployment
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+    if: ${{ inputs.monitoring_option == 'all' || inputs.monitoring_option == 'Datadog' }}
     needs: [set-environments, check-secrets]
     env:
       CLUSTER_ENV: ${{ matrix.environment-type }}

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -29,7 +29,7 @@ jobs:
         name: Filter environments
         uses: mikefarah/yq@master
         with:
-          cmd: yq 'with_entries(select(.value.datadogEnabled)) | keys' github-env.yaml -o json
+          cmd: yq 'with_entries(select(.value.monitoringEnabled)) | keys' github-env.yaml -o json
 
   check-environment-secrets:
     name: Check that sufficient secrets are specified for environment name
@@ -41,9 +41,9 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
-        environment-types: [staging, production]
-      exclude:
-        - environment-name: trv
+        environment-types: [production]
+      include:
+        - environment-name: Biomage
           environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
@@ -76,8 +76,8 @@ jobs:
             exit 1
           fi
 
-  deploy-cloudwatch-monitoring:
-    name: Setup Cloudwatch monitoring for deployment
+  deploy-cloudwatch-logs:
+    name: Setup Cloudwatch logging for deployment
     runs-on: ubuntu-20.04
     needs: [set-environments, check-secrets]
     env:
@@ -87,9 +87,9 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
-        environment-type: [staging, production]
-        exclude:
-          - environment-name: trv
+        environment-type: [production]
+        include:
+          - environment-name: Biomage
             environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
@@ -196,9 +196,9 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.datadog-envs) }}
-        environment-type: [staging, production]
+        environment-type: [production]
         exclude:
-          - environment-name: trv
+          - environment-name: Biomage
             environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
@@ -259,7 +259,7 @@ jobs:
   report-if-failed:
     name: Report if workflow failed
     runs-on: ubuntu-20.04
-    needs: [set-environments, check-secrets, deploy-cloudwatch-monitoring, deploy-datadog-monitoring]
+    needs: [set-environments, check-secrets, deploy-cloudwatch-logs, deploy-datadog-monitoring]
     if: failure() && github.ref == 'refs/heads/master'
     steps:
       - id: send-to-slack

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -8,44 +8,12 @@ on:
 concurrency: cluster-update-mutex
 
 jobs:
-  set-environments:
-    name: Set environments
-    runs-on: ubuntu-20.04
-    outputs:
-      all-envs: ${{ steps.get-all-envs.outputs.result }}
-      datadog-envs: ${{ steps.get-datadog-enabled-envs.outputs.result }}
-    steps:
-      - id: checkout
-        name: Check out source code
-        uses: actions/checkout@v2
-
-      - id: get-all-envs
-        name: Get all environments
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq 'keys' infra/config/github-environments-config.yaml -o json
-
-      - id: get-datadog-enabled-envs
-        name: Get Datadog enabled envs
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq 'with_entries(select(.value.monitoringEnabled)) | keys' infra/config/github-environments-config.yaml -o json
-
-      - id: test-datadog-enabled-envs
-        name: Test Datadog enabled envs
-        run: |-
-          echo "Datadog-enabled envs '${{ steps.get-datadog-enabled-envs.outputs.result }}'"
-
   check-secrets:
     name: Check that sufficient secrets are specified for environment name
     runs-on: ubuntu-20.04
-    needs: set-environments
-    env:
-      CLUSTER_ENV: ${{ matrix.environment-type }}
     strategy:
-      max-parallel: 1
       matrix:
-        environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
+        environment-name: [Biomage, trv]
     environment: ${{ matrix.environment-name }}
     steps:
       - id: check-secrets
@@ -69,6 +37,12 @@ jobs:
             ERROR=true
           fi
 
+          if [ -z "${{ secrets.DATADOG_API_KEY}}" ]
+          then
+            echo Datadog API key is not defined.
+            ERROR=true
+          fi
+
           if [ ! -z "$ERROR" ]
           then
             echo
@@ -77,17 +51,17 @@ jobs:
             exit 1
           fi
 
-  deploy-cloudwatch-logs:
-    name: Setup Cloudwatch logging for deployment
+  deploy-monitoring:
+    name: Setup logging and monitoring
     runs-on: ubuntu-20.04
-    needs: [set-environments, check-secrets]
+    needs: check-secrets
     env:
       CLUSTER_ENV: ${{ matrix.environment-type }}
       API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
     strategy:
       max-parallel: 1
       matrix:
-        environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
+        environment-name: [Biomage, trv]
         environment-type: [staging, production]
         exclude:
           - environment-name: trv
@@ -186,60 +160,6 @@ jobs:
 
           kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
-  deploy-datadog-monitoring:
-    name: Setup Datadog monitoring for deployment
-    runs-on: ubuntu-20.04
-    needs: [set-environments, check-secrets]
-    env:
-      CLUSTER_ENV: ${{ matrix.environment-type }}
-      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-    strategy:
-      max-parallel: 1
-      matrix:
-        environment-name: ${{ fromJson(needs.set-environments.outputs.datadog-envs) }}
-        environment-type: [staging, production]
-        exclude:
-          - environment-name: trv
-            environment-type: staging
-    environment: ${{ matrix.environment-name }}
-    steps:
-      - id: check-datadog-secrets
-        name: Check if necessary Datadog secrets are installed.
-        if: ${{ steps.datadog-enabled.outputs.result }}
-        run: |-
-          echo Checking if Datadog secrets are defined in the repository.
-
-          if [ -z "${{ secrets.DATADOG_API_KEY}}" ]
-          then
-            echo Datadog API key is not defined.
-            ERROR=true
-          fi
-
-          if [ ! -z "$ERROR" ]
-          then
-            echo
-            echo This workflow requires some Datadog secrets to complete.
-            echo Please make sure they are created by adding/rotating them manually.
-            exit 1
-          fi
-
-      - id: checkout
-        name: Check out source code
-        uses: actions/checkout@v2
-
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
-
       # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
       - id: setup-datadog-cluster-agent
         name: Setup Datadog cluster agent
@@ -260,7 +180,7 @@ jobs:
   report-if-failed:
     name: Report if workflow failed
     runs-on: ubuntu-20.04
-    needs: [set-environments, check-secrets, deploy-cloudwatch-logs, deploy-datadog-monitoring]
+    needs: [check-secrets, deploy-monitoring]
     if: failure() && github.ref == 'refs/heads/master'
     steps:
       - id: send-to-slack

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -31,6 +31,11 @@ jobs:
         with:
           cmd: yq 'with_entries(select(.value.monitoringEnabled)) | keys' github-env.yaml -o json
 
+      - id: test-datadog-enabled-envs
+        name: Test Datadog enabled envs
+        run: |-
+          echo "Datadog-enabled envs '${{ steps.get-datadog-enabled-envs.outputs.result }}'"
+
   check-environment-secrets:
     name: Check that sufficient secrets are specified for environment name
     runs-on: ubuntu-20.04
@@ -97,93 +102,93 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: setup-cluster-cloudwatch-logging-policy
-        name: Setup permissions required for cluster to log to Cloudwatch
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }}"
-          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-          no-fail-on-empty-changeset: "1"
-          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+      # - id: setup-cluster-cloudwatch-logging-policy
+      #   name: Setup permissions required for cluster to log to Cloudwatch
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
+      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+      #     no-fail-on-empty-changeset: "1"
+      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      # Setting up log forwarding for pods hosted in EC2 nodes
-      - id: create-fluent-bit-namespace
-        name: Create namespace for node FluentBit deployment
-        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+      # # Setting up log forwarding for pods hosted in EC2 nodes
+      # - id: create-fluent-bit-namespace
+      #   name: Create namespace for node FluentBit deployment
+      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      - id: create-service-account-for-node-fluent-bit
-        name: Create service account for node FluentBit
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          eksctl create iamserviceaccount \
-            --name fluent-bit \
-            --namespace node-logging \
-            --cluster biomage-$CLUSTER_ENV \
-            --role-name irsa-fluent-bit-$CLUSTER_ENV \
-            --attach-policy-arn $LOGGING_POLICY_ARN \
-            --override-existing-serviceaccounts \
-            --approve
+      # - id: create-service-account-for-node-fluent-bit
+      #   name: Create service account for node FluentBit
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     eksctl create iamserviceaccount \
+      #       --name fluent-bit \
+      #       --namespace node-logging \
+      #       --cluster biomage-$CLUSTER_ENV \
+      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
+      #       --attach-policy-arn $LOGGING_POLICY_ARN \
+      #       --override-existing-serviceaccounts \
+      #       --approve
 
-      - id: deploy-node-fluent-bit
-        name: Deploy FluentBit for EC2 nodes
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |
-          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-          # We do not want to log everything for costs/security concerns
+      # - id: deploy-node-fluent-bit
+      #   name: Deploy FluentBit for EC2 nodes
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |
+      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+      #     # We do not want to log everything for costs/security concerns
 
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
-      # Setting up log forwarding for pods hosted on Fargate nodes
-      - id: attach-pod-execution-role-name
-        name: Attach logging policy to pod execution role
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+      # # Setting up log forwarding for pods hosted on Fargate nodes
+      # - id: attach-pod-execution-role-name
+      #   name: Attach logging policy to pod execution role
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-            --cluster-name biomage-$CLUSTER_ENV \
-            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+      #       --cluster-name biomage-$CLUSTER_ENV \
+      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      - id: deploy-fargate-fluent-bit
-        name: Deploy FluentBit config for Fargate pods
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |-
-          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      # - id: deploy-fargate-fluent-bit
+      #   name: Deploy FluentBit config for Fargate pods
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |-
+      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
   deploy-datadog-monitoring:
     name: Setup Datadog monitoring for deployment
@@ -226,35 +231,35 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      - id: setup-datadog-cluster-agent
-        name: Setup Datadog cluster agent
-        run: |-
-          helm repo add datadog https://helm.datadoghq.com
-          helm repo update
-          helm upgrade datadog-agent datadog/datadog \
-            -f infra/datadog/cluster-agent-values.yaml \
-            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-            --set datadog.clusterName=biomage-$CLUSTER_ENV \
-            --install
+      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      # - id: setup-datadog-cluster-agent
+      #   name: Setup Datadog cluster agent
+      #   run: |-
+      #     helm repo add datadog https://helm.datadoghq.com
+      #     helm repo update
+      #     helm upgrade datadog-agent datadog/datadog \
+      #       -f infra/datadog/cluster-agent-values.yaml \
+      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
+      #       --install
 
-      - id: setup-datadog-sidecar-permissions
-        name: Setup Datadog sidecar permissions
-        run: |-
-          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      # - id: setup-datadog-sidecar-permissions
+      #   name: Setup Datadog sidecar permissions
+      #   run: |-
+      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -167,41 +167,41 @@ jobs:
         run: |-
           echo "Running for Cloudwatch"
 
-    deploy-datadog-monitoring:
-      name: Setup Datadog monitoring for deployment
-      runs-on: ubuntu-20.04
-      if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
-      needs: [set-environments, check-secrets]
-      env:
-        CLUSTER_ENV: ${{ matrix.environment-type }}
-        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      strategy:
-        max-parallel: 1
-        matrix:
-          environment-type: ${{ fromJson(needs.set-environments.outputs.env-type) }}
-          environment-name: ${{ fromJson(needs.set-environments.outputs.env-name) }}
-          exclude:
-            - environment-name: trv
-              environment-type: staging
-      environment: ${{ matrix.environment-name }}
-      steps:
-        - id: checkout
-          name: Check out source code
-          uses: actions/checkout@v2
+  deploy-datadog-monitoring:
+    name: Setup Datadog monitoring for deployment
+    runs-on: ubuntu-20.04
+    if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+    needs: [set-environments, check-secrets]
+    env:
+      CLUSTER_ENV: ${{ matrix.environment-type }}
+      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        environment-type: ${{ fromJson(needs.set-environments.outputs.env-type) }}
+        environment-name: ${{ fromJson(needs.set-environments.outputs.env-name) }}
+        exclude:
+          - environment-name: trv
+            environment-type: staging
+    environment: ${{ matrix.environment-name }}
+    steps:
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
 
-        - id: setup-aws
-          name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@v1
-          with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            aws-region: ${{ secrets.AWS_REGION }}
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-        - id: test-if-statement-2
-          if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
-          name: Testing if statement Datadog
-          run: |-
-            echo "Running for Datadog"
+      - id: test-if-statement-2
+        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+        name: Testing if statement Datadog
+        run: |-
+          echo "Running for Datadog"
 
       # - id: add-kubeconfig
       #   name: Add k8s config file for existing cluster.
@@ -313,7 +313,7 @@ jobs:
   report-if-failed:
     name: Report if workflow failed
     runs-on: ubuntu-20.04
-    needs: [set-environments, check-secrets, deploy-monitoring]
+    needs: [set-environments, check-secrets, deploy-cloudwatch-monitoring, deploy-datadog-monitoring]
     if: failure() && github.ref == 'refs/heads/master'
     steps:
       - id: send-to-slack

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -72,110 +72,110 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      - id: setup-aws
-        name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      # - id: setup-aws
+      #   name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: setup-cluster-cloudwatch-logging-policy
-        name: Setup permissions required for cluster to log to Cloudwatch
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }}"
-          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-          no-fail-on-empty-changeset: "1"
-          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+      # - id: setup-cluster-cloudwatch-logging-policy
+      #   name: Setup permissions required for cluster to log to Cloudwatch
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
+      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+      #     no-fail-on-empty-changeset: "1"
+      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      # Setting up log forwarding for pods hosted in EC2 nodes
-      - id: create-fluent-bit-namespace
-        name: Create namespace for node FluentBit deployment
-        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+      # # Setting up log forwarding for pods hosted in EC2 nodes
+      # - id: create-fluent-bit-namespace
+      #   name: Create namespace for node FluentBit deployment
+      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      - id: create-service-account-for-node-fluent-bit
-        name: Create service account for node FluentBit
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          eksctl create iamserviceaccount \
-            --name fluent-bit \
-            --namespace node-logging \
-            --cluster biomage-$CLUSTER_ENV \
-            --role-name irsa-fluent-bit-$CLUSTER_ENV \
-            --attach-policy-arn $LOGGING_POLICY_ARN \
-            --override-existing-serviceaccounts \
-            --approve
+      # - id: create-service-account-for-node-fluent-bit
+      #   name: Create service account for node FluentBit
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     eksctl create iamserviceaccount \
+      #       --name fluent-bit \
+      #       --namespace node-logging \
+      #       --cluster biomage-$CLUSTER_ENV \
+      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
+      #       --attach-policy-arn $LOGGING_POLICY_ARN \
+      #       --override-existing-serviceaccounts \
+      #       --approve
 
-      - id: deploy-node-fluent-bit
-        name: Deploy FluentBit for EC2 nodes
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |
-          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-          # We do not want to log everything for costs/security concerns
+      # - id: deploy-node-fluent-bit
+      #   name: Deploy FluentBit for EC2 nodes
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |
+      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+      #     # We do not want to log everything for costs/security concerns
 
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
-      # Setting up log forwarding for pods hosted on Fargate nodes
-      - id: attach-pod-execution-role-name
-        name: Attach logging policy to pod execution role
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+      # # Setting up log forwarding for pods hosted on Fargate nodes
+      # - id: attach-pod-execution-role-name
+      #   name: Attach logging policy to pod execution role
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-            --cluster-name biomage-$CLUSTER_ENV \
-            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+      #       --cluster-name biomage-$CLUSTER_ENV \
+      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      - id: deploy-fargate-fluent-bit
-        name: Deploy FluentBit config for Fargate pods
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |-
-          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      # - id: deploy-fargate-fluent-bit
+      #   name: Deploy FluentBit config for Fargate pods
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |-
+      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
-      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      - id: setup-datadog-cluster-agent
-        name: Setup Datadog cluster agent
-        run: |-
-          helm repo add datadog https://helm.datadoghq.com
-          helm repo update
-          helm upgrade datadog-agent datadog/datadog \
-            -f infra/datadog/cluster-agent-values.yaml \
-            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-            --set datadog.clusterName=biomage-$CLUSTER_ENV \
-            --install
+      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      # - id: setup-datadog-cluster-agent
+      #   name: Setup Datadog cluster agent
+      #   run: |-
+      #     helm repo add datadog https://helm.datadoghq.com
+      #     helm repo update
+      #     helm upgrade datadog-agent datadog/datadog \
+      #       -f infra/datadog/cluster-agent-values.yaml \
+      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
+      #       --install
 
-      - id: setup-datadog-sidecar-permissions
-        name: Setup Datadog sidecar permissions
-        run: |-
-          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      # - id: setup-datadog-sidecar-permissions
+      #   name: Setup Datadog sidecar permissions
+      #   run: |-
+      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -91,7 +91,7 @@ jobs:
         environment-type: [staging, production]
         exclude:
           - environment-name: trv
-            environment-type: production
+            environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
       - id: checkout
@@ -200,7 +200,7 @@ jobs:
         environment-type: [staging, production]
         exclude:
           - environment-name: trv
-            environment-type: production
+            environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
       - id: check-datadog-secrets

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -132,9 +132,10 @@ jobs:
             exit 1
           fi
 
-  deploy-monitoring:
-    name: Setup monitoring for deployment
+  deploy-cloudwatch-monitoring:
+    name: Setup Cloudwatch monitoring for deployment
     runs-on: ubuntu-20.04
+    if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
     needs: [set-environments, check-secrets]
     env:
       CLUSTER_ENV: ${{ matrix.environment-type }}
@@ -163,15 +164,44 @@ jobs:
 
       - id: test-if-statement-1
         name: Testing if statement Cloudwatch
-        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
         run: |-
           echo "Running for Cloudwatch"
 
-      - id: test-if-statement-2
-        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
-        name: Testing if statement Datadog
-        run: |-
-          echo "Running for Datadog"
+    deploy-datadog-monitoring:
+      name: Setup Datadog monitoring for deployment
+      runs-on: ubuntu-20.04
+      if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+      needs: [set-environments, check-secrets]
+      env:
+        CLUSTER_ENV: ${{ matrix.environment-type }}
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      strategy:
+        max-parallel: 1
+        matrix:
+          environment-type: ${{ fromJson(needs.set-environments.outputs.env-type) }}
+          environment-name: ${{ fromJson(needs.set-environments.outputs.env-name) }}
+          exclude:
+            - environment-name: trv
+              environment-type: staging
+      environment: ${{ matrix.environment-name }}
+      steps:
+        - id: checkout
+          name: Check out source code
+          uses: actions/checkout@v2
+
+        - id: setup-aws
+          name: Configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@v1
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: ${{ secrets.AWS_REGION }}
+
+        - id: test-if-statement-2
+          if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+          name: Testing if statement Datadog
+          run: |-
+            echo "Running for Datadog"
 
       # - id: add-kubeconfig
       #   name: Add k8s config file for existing cluster.

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -161,10 +161,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: test-deployment
-        name: Setting up
+      - id: test-if-statement-1
+        name: Testing if statement Cloudwatch
+        if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
         run: |-
-          echo "Deploying clusters for ${{ matrix.environment-name }} - $CLUSTER_ENV"
+          echo "Running for Cloudwatch"
+
+      - id: test-if-statement-2
+        if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
+        name: Testing if statement Datadog
+        run: |-
+          echo "Running for Datadog"
 
       # - id: add-kubeconfig
       #   name: Add k8s config file for existing cluster.

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -23,13 +23,13 @@ jobs:
         name: Filter environments
         uses: mikefarah/yq@master
         with:
-          cmd: yq 'keys' github-env.yaml -o json
+          cmd: yq 'keys' infra/config/github-environments-config.yaml -o json
 
       - id: get-datadog-enabled-envs
         name: Filter environments
         uses: mikefarah/yq@master
         with:
-          cmd: yq 'with_entries(select(.value.monitoringEnabled)) | keys' github-env.yaml -o json
+          cmd: yq 'with_entries(select(.value.monitoringEnabled)) | keys' infra/config/github-environments-config.yaml -o json
 
       - id: test-datadog-enabled-envs
         name: Test Datadog enabled envs

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |-
           echo "Datadog-enabled envs '${{ steps.get-datadog-enabled-envs.outputs.result }}'"
 
-  check-environment-secrets:
+  check-secrets:
     name: Check that sufficient secrets are specified for environment name
     runs-on: ubuntu-20.04
     needs: set-environments

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -71,110 +71,110 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      # - id: setup-aws
-      #   name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_REGION }}
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # - id: install-eksctl
-      #   name: Install eksctl
-      #   run: |-
-      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-      #     sudo mv /tmp/eksctl /usr/local/bin
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
 
-      # - id: setup-cluster-cloudwatch-logging-policy
-      #   name: Setup permissions required for cluster to log to Cloudwatch
-      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
-      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-      #     no-fail-on-empty-changeset: "1"
-      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+      - id: setup-cluster-cloudwatch-logging-policy
+        name: Setup permissions required for cluster to log to Cloudwatch
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }}"
+          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+          no-fail-on-empty-changeset: "1"
+          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      # # Setting up log forwarding for pods hosted in EC2 nodes
-      # - id: create-fluent-bit-namespace
-      #   name: Create namespace for node FluentBit deployment
-      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+      # Setting up log forwarding for pods hosted in EC2 nodes
+      - id: create-fluent-bit-namespace
+        name: Create namespace for node FluentBit deployment
+        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      # - id: create-service-account-for-node-fluent-bit
-      #   name: Create service account for node FluentBit
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     eksctl create iamserviceaccount \
-      #       --name fluent-bit \
-      #       --namespace node-logging \
-      #       --cluster biomage-$CLUSTER_ENV \
-      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
-      #       --attach-policy-arn $LOGGING_POLICY_ARN \
-      #       --override-existing-serviceaccounts \
-      #       --approve
+      - id: create-service-account-for-node-fluent-bit
+        name: Create service account for node FluentBit
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          eksctl create iamserviceaccount \
+            --name fluent-bit \
+            --namespace node-logging \
+            --cluster biomage-$CLUSTER_ENV \
+            --role-name irsa-fluent-bit-$CLUSTER_ENV \
+            --attach-policy-arn $LOGGING_POLICY_ARN \
+            --override-existing-serviceaccounts \
+            --approve
 
-      # - id: deploy-node-fluent-bit
-      #   name: Deploy FluentBit for EC2 nodes
-      #   env:
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #   run: |
-      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-      #     # We do not want to log everything for costs/security concerns
+      - id: deploy-node-fluent-bit
+        name: Deploy FluentBit for EC2 nodes
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+          # We do not want to log everything for costs/security concerns
 
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
-      # # Setting up log forwarding for pods hosted on Fargate nodes
-      # - id: attach-pod-execution-role-name
-      #   name: Attach logging policy to pod execution role
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+      # Setting up log forwarding for pods hosted on Fargate nodes
+      - id: attach-pod-execution-role-name
+        name: Attach logging policy to pod execution role
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-      #       --cluster-name biomage-$CLUSTER_ENV \
-      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+            --cluster-name biomage-$CLUSTER_ENV \
+            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      # - id: deploy-fargate-fluent-bit
-      #   name: Deploy FluentBit config for Fargate pods
-      #   env:
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #   run: |-
-      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      - id: deploy-fargate-fluent-bit
+        name: Deploy FluentBit config for Fargate pods
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |-
+          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
-      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      # - id: setup-datadog-cluster-agent
-      #   name: Setup Datadog cluster agent
-      #   run: |-
-      #     helm repo add datadog https://helm.datadoghq.com
-      #     helm repo update
-      #     helm upgrade datadog-agent datadog/datadog \
-      #       -f infra/datadog/cluster-agent-values.yaml \
-      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
-      #       --install
+      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      - id: setup-datadog-cluster-agent
+        name: Setup Datadog cluster agent
+        run: |-
+          helm repo add datadog https://helm.datadoghq.com
+          helm repo update
+          helm upgrade datadog-agent datadog/datadog \
+            -f infra/datadog/cluster-agent-values.yaml \
+            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+            --set datadog.clusterName=biomage-$CLUSTER_ENV \
+            --install
 
-      # - id: setup-datadog-sidecar-permissions
-      #   name: Setup Datadog sidecar permissions
-      #   run: |-
-      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      - id: setup-datadog-sidecar-permissions
+        name: Setup Datadog sidecar permissions
+        run: |-
+          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -59,7 +59,6 @@ jobs:
       CLUSTER_ENV: ${{ matrix.environment-type }}
       API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
     strategy:
-      max-parallel: 1
       matrix:
         environment-name: [Biomage, trv]
         environment-type: [staging, production]

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -1,4 +1,4 @@
-name: Deploy monitoring in a deployment
+name: Deploy cluster monitoring
 
 on:
   workflow_dispatch:
@@ -202,7 +202,7 @@ jobs:
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.datadog-envs) }}
         environment-type: [production]
-        exclude:
+        include:
           - environment-name: Biomage
             environment-type: staging
     environment: ${{ matrix.environment-name }}

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -3,22 +3,82 @@ name: Setup monitoring for a deployment
 on:
   workflow_dispatch:
     inputs:
-      cluster:
+      environment_name:
         type: choice
-        description: Select cluster
+        description: Select the environment name to run the actions on
         options:
-        - staging
-        - production
-        - staging and production
+          - trv
+          - Biomage
+          - all
+        default: all
+      deployment_option:
+        type: choice
+        description: Select the monitoring to configure
+        options:
+          - Datadog
+          - Cloudwatch
+          - all
+        default: Cloudwatch
+      environment_type:
+        type: choice
+        description: Select environment type
+        options:
+          - staging
+          - production
+          - staging and production
         default: staging
 
+# this ensures that only one CI pipeline with the same key
+#  can run at once in order to prevent undefined states
+concurrency: cluster-update-mutex
+
 jobs:
-  setup:
-    name: Check secrets and set up matrix
+  set-environments:
+    name: Set up environment name and environment type for action run
     runs-on: ubuntu-20.04
+    outputs:
+      env-type: ${{ steps.set-env-type.outputs.env-type }}
+      env-name: ${{ steps.set-env-name.outputs.env-name }}
+    steps:
+      - id: set-env-type
+        name: Set up environment type
+        run: |-
+          if [ "${ENVIRONMENT_TYPE}" = "staging" ]; then
+            echo 'env-type=["staging"]' >> $GITHUB_OUTPUT
+          elif [ "${ENVIRONMENT_TYPE}" = "production" ]; then
+            echo 'env-type=["production"]' >> $GITHUB_OUTPUT
+          elif [ "${ENVIRONMENT_TYPE}" = "staging and production" ]; then
+            echo 'env-type=["staging", "production"]' >> $GITHUB_OUTPUT
+          fi
+        env:
+          ENVIRONMENT_TYPE: ${{ github.event.inputs.environment_type }}
+
+      - id: set-env-name
+        name: Set up environment name
+        run: |-
+          if [ "${ENVIRONMENT_NAME}" = "all" ]; then
+            echo 'env-name=["Biomage", "trv"]' >> $GITHUB_OUTPUT
+          elif [ "${ENVIRONMENT_NAME}" = "trv" ]; then
+            echo 'env-name=["trv"]' >> $GITHUB_OUTPUT
+          elif [ "${ENVIRONMENT_NAME}" = "Biomage" ]; then
+            echo 'env-name=["Biomage"]' >> $GITHUB_OUTPUT
+          fi
+        env:
+          ENVIRONMENT_NAME: ${{ github.event.inputs.environment_name }}
+
+  check-secrets:
+    name: Check that sufficient secrets are specified for environment name
+    runs-on: ubuntu-20.04
+    needs: set-environments
+    env:
+      CLUSTER_ENV: ${{ matrix.environment-type }}
     strategy:
       matrix:
-        environment-name: [Biomage]
+        environment-type: ${{ fromJson(needs.set-environments.outputs.env-type) }}
+        environment-name: ${{ fromJson(needs.set-environments.outputs.env-name) }}
+        exclude:
+          - environment-name: trv
+            environment-type: staging
     environment: ${{ matrix.environment-name }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -26,7 +86,37 @@ jobs:
       - id: check-secrets
         name: Check if necessary secrets are installed.
         run: |-
-          echo Checking if secrets are defined in the repository.
+          echo Checking if required secrets are defined in the repository.
+
+          if [ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ]
+          then
+            echo AWS Access Key ID not defined.
+            ERROR=true
+          fi
+          if [ -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]
+          then
+            echo AWS Secret Access Key not defined.
+            ERROR=true
+          fi
+          if [ -z "${{ secrets.API_TOKEN_GITHUB }}" ]
+          then
+            echo GitHub deploy key access token not defined.
+            ERROR=true
+          fi
+
+          if [ ! -z "$ERROR" ]
+          then
+            echo
+            echo This workflow requires some secrets to complete.
+            echo Please make sure they are created by adding/rotating them manually.
+            exit 1
+          fi
+
+      - id: check-datadog-secrets
+        name: Check if necessary Datadog secrets are installed.
+        if: ${{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
+        run: |-
+          echo Checking if Datadog secrets are defined in the repository.
 
           if [ -z "${{ secrets.DATADOG_API_KEY}}" ]
           then
@@ -37,35 +127,26 @@ jobs:
           if [ ! -z "$ERROR" ]
           then
             echo
-            echo This workflow requires some secrets to complete.
-            echo Please make they are created by adding/rotating them manually.
+            echo This workflow requires some Datadog secrets to complete.
+            echo Please make sure they are created by adding/rotating them manually.
             exit 1
           fi
-      - id: set-matrix
-        name: Set up cluster matrix
-        run: |-
-          if [ "${CLUSTER}" = "staging" ]; then
-            echo '::set-output name=matrix::["staging"]'
-          elif [ "${CLUSTER}" = "production" ]; then
-            echo '::set-output name=matrix::["production"]'
-          elif [ "${CLUSTER}" = "staging and production" ]; then
-            echo '::set-output name=matrix::["staging", "production"]'
-          fi
-        env:
-          CLUSTER: ${{ github.event.inputs.cluster }}
 
   deploy-monitoring:
     name: Setup monitoring for deployment
     runs-on: ubuntu-20.04
-    needs: [setup]
+    needs: [set-environments, check-secrets]
     env:
       CLUSTER_ENV: ${{ matrix.environment-type }}
       API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
     strategy:
       max-parallel: 1
       matrix:
-        environment-type: ${{ fromJson(needs.setup.outputs.matrix) }}
-        environment-name: [Biomage]
+        environment-type: ${{ fromJson(needs.set-environments.outputs.env-type) }}
+        environment-name: ${{ fromJson(needs.set-environments.outputs.env-name) }}
+        exclude:
+          - environment-name: trv
+            environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
       - id: checkout
@@ -82,17 +163,20 @@ jobs:
 
       - id: add-kubeconfig
         name: Add k8s config file for existing cluster.
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         run: |-
           aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
       - id: install-eksctl
         name: Install eksctl
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         run: |-
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
       - id: setup-cluster-cloudwatch-logging-policy
         name: Setup permissions required for cluster to log to Cloudwatch
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           parameter-overrides: "Environment=${{ matrix.environment-type }}"
@@ -104,10 +188,12 @@ jobs:
       # Setting up log forwarding for pods hosted in EC2 nodes
       - id: create-fluent-bit-namespace
         name: Create namespace for node FluentBit deployment
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
       - id: create-service-account-for-node-fluent-bit
         name: Create service account for node FluentBit
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         env:
           LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
         run: |-
@@ -122,6 +208,7 @@ jobs:
 
       - id: deploy-node-fluent-bit
         name: Deploy FluentBit for EC2 nodes
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
@@ -136,6 +223,7 @@ jobs:
       # Setting up log forwarding for pods hosted on Fargate nodes
       - id: attach-pod-execution-role-name
         name: Attach logging policy to pod execution role
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         env:
           LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
         run: |-
@@ -151,6 +239,7 @@ jobs:
 
       - id: deploy-fargate-fluent-bit
         name: Deploy FluentBit config for Fargate pods
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |-
@@ -163,6 +252,7 @@ jobs:
       # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
       - id: setup-datadog-cluster-agent
         name: Setup Datadog cluster agent
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
         run: |-
           helm repo add datadog https://helm.datadoghq.com
           helm repo update
@@ -174,6 +264,7 @@ jobs:
 
       - id: setup-datadog-sidecar-permissions
         name: Setup Datadog sidecar permissions
+        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
         run: |-
           kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -98,93 +98,93 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      # - id: setup-aws
-      #   name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_REGION }}
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # - id: install-eksctl
-      #   name: Install eksctl
-      #   run: |-
-      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-      #     sudo mv /tmp/eksctl /usr/local/bin
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
 
-      # - id: setup-cluster-cloudwatch-logging-policy
-      #   name: Setup permissions required for cluster to log to Cloudwatch
-      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
-      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-      #     no-fail-on-empty-changeset: "1"
-      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+      - id: setup-cluster-cloudwatch-logging-policy
+        name: Setup permissions required for cluster to log to Cloudwatch
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }}"
+          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+          no-fail-on-empty-changeset: "1"
+          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      # # Setting up log forwarding for pods hosted in EC2 nodes
-      # - id: create-fluent-bit-namespace
-      #   name: Create namespace for node FluentBit deployment
-      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+      # Setting up log forwarding for pods hosted in EC2 nodes
+      - id: create-fluent-bit-namespace
+        name: Create namespace for node FluentBit deployment
+        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      # - id: create-service-account-for-node-fluent-bit
-      #   name: Create service account for node FluentBit
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     eksctl create iamserviceaccount \
-      #       --name fluent-bit \
-      #       --namespace node-logging \
-      #       --cluster biomage-$CLUSTER_ENV \
-      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
-      #       --attach-policy-arn $LOGGING_POLICY_ARN \
-      #       --override-existing-serviceaccounts \
-      #       --approve
+      - id: create-service-account-for-node-fluent-bit
+        name: Create service account for node FluentBit
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          eksctl create iamserviceaccount \
+            --name fluent-bit \
+            --namespace node-logging \
+            --cluster biomage-$CLUSTER_ENV \
+            --role-name irsa-fluent-bit-$CLUSTER_ENV \
+            --attach-policy-arn $LOGGING_POLICY_ARN \
+            --override-existing-serviceaccounts \
+            --approve
 
-      # - id: deploy-node-fluent-bit
-      #   name: Deploy FluentBit for EC2 nodes
-      #   env:
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #   run: |
-      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-      #     # We do not want to log everything for costs/security concerns
+      - id: deploy-node-fluent-bit
+        name: Deploy FluentBit for EC2 nodes
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+          # We do not want to log everything for costs/security concerns
 
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
-      # # Setting up log forwarding for pods hosted on Fargate nodes
-      # - id: attach-pod-execution-role-name
-      #   name: Attach logging policy to pod execution role
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+      # Setting up log forwarding for pods hosted on Fargate nodes
+      - id: attach-pod-execution-role-name
+        name: Attach logging policy to pod execution role
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-      #       --cluster-name biomage-$CLUSTER_ENV \
-      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+            --cluster-name biomage-$CLUSTER_ENV \
+            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-      # - id: deploy-fargate-fluent-bit
-      #   name: Deploy FluentBit config for Fargate pods
-      #   env:
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #   run: |-
-      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      - id: deploy-fargate-fluent-bit
+        name: Deploy FluentBit config for Fargate pods
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |-
+          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
   deploy-datadog-monitoring:
     name: Setup Datadog monitoring for deployment
@@ -227,35 +227,35 @@ jobs:
         name: Check out source code
         uses: actions/checkout@v2
 
-      # - id: setup-aws
-      #   name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: ${{ secrets.AWS_REGION }}
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      # - id: setup-datadog-cluster-agent
-      #   name: Setup Datadog cluster agent
-      #   run: |-
-      #     helm repo add datadog https://helm.datadoghq.com
-      #     helm repo update
-      #     helm upgrade datadog-agent datadog/datadog \
-      #       -f infra/datadog/cluster-agent-values.yaml \
-      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
-      #       --install
+      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      - id: setup-datadog-cluster-agent
+        name: Setup Datadog cluster agent
+        run: |-
+          helm repo add datadog https://helm.datadoghq.com
+          helm repo update
+          helm upgrade datadog-agent datadog/datadog \
+            -f infra/datadog/cluster-agent-values.yaml \
+            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+            --set datadog.clusterName=biomage-$CLUSTER_ENV \
+            --install
 
-      # - id: setup-datadog-sidecar-permissions
-      #   name: Setup Datadog sidecar permissions
-      #   run: |-
-      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      - id: setup-datadog-sidecar-permissions
+        name: Setup Datadog sidecar permissions
+        run: |-
+          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -272,6 +272,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+
       # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
       - id: setup-datadog-cluster-agent
         name: Setup Datadog cluster agent

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -161,112 +161,117 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      - id: test-deployment
+        name: Setting up
         run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+          echo "Deploying clusters for ${{ matrix.environment-name }} - $CLUSTER_ENV"
 
-      - id: install-eksctl
-        name: Install eksctl
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: setup-cluster-cloudwatch-logging-policy
-        name: Setup permissions required for cluster to log to Cloudwatch
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }}"
-          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-          no-fail-on-empty-changeset: "1"
-          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
-      # Setting up log forwarding for pods hosted in EC2 nodes
-      - id: create-fluent-bit-namespace
-        name: Create namespace for node FluentBit deployment
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+      # - id: setup-cluster-cloudwatch-logging-policy
+      #   name: Setup permissions required for cluster to log to Cloudwatch
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
+      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+      #     no-fail-on-empty-changeset: "1"
+      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      - id: create-service-account-for-node-fluent-bit
-        name: Create service account for node FluentBit
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          eksctl create iamserviceaccount \
-            --name fluent-bit \
-            --namespace node-logging \
-            --cluster biomage-$CLUSTER_ENV \
-            --role-name irsa-fluent-bit-$CLUSTER_ENV \
-            --attach-policy-arn $LOGGING_POLICY_ARN \
-            --override-existing-serviceaccounts \
-            --approve
+      # # Setting up log forwarding for pods hosted in EC2 nodes
+      # - id: create-fluent-bit-namespace
+      #   name: Create namespace for node FluentBit deployment
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
-      - id: deploy-node-fluent-bit
-        name: Deploy FluentBit for EC2 nodes
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |
-          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-          # We do not want to log everything for costs/security concerns
+      # - id: create-service-account-for-node-fluent-bit
+      #   name: Create service account for node FluentBit
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     eksctl create iamserviceaccount \
+      #       --name fluent-bit \
+      #       --namespace node-logging \
+      #       --cluster biomage-$CLUSTER_ENV \
+      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
+      #       --attach-policy-arn $LOGGING_POLICY_ARN \
+      #       --override-existing-serviceaccounts \
+      #       --approve
 
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+      # - id: deploy-node-fluent-bit
+      #   name: Deploy FluentBit for EC2 nodes
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |
+      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+      #     # We do not want to log everything for costs/security concerns
 
-          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
 
-      # Setting up log forwarding for pods hosted on Fargate nodes
-      - id: attach-pod-execution-role-name
-        name: Attach logging policy to pod execution role
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        env:
-          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-        run: |-
-          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
 
-          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-            --cluster-name biomage-$CLUSTER_ENV \
-            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+      # # Setting up log forwarding for pods hosted on Fargate nodes
+      # - id: attach-pod-execution-role-name
+      #   name: Attach logging policy to pod execution role
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   env:
+      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+      #   run: |-
+      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
 
-          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+      #       --cluster-name biomage-$CLUSTER_ENV \
+      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
 
-      - id: deploy-fargate-fluent-bit
-        name: Deploy FluentBit config for Fargate pods
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |-
-          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
 
-          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
+      # - id: deploy-fargate-fluent-bit
+      #   name: Deploy FluentBit config for Fargate pods
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   env:
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #   run: |-
+      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
 
-      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      - id: setup-datadog-cluster-agent
-        name: Setup Datadog cluster agent
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
-        run: |-
-          helm repo add datadog https://helm.datadoghq.com
-          helm repo update
-          helm upgrade datadog-agent datadog/datadog \
-            -f infra/datadog/cluster-agent-values.yaml \
-            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-            --set datadog.clusterName=biomage-$CLUSTER_ENV \
-            --install
+      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
-      - id: setup-datadog-sidecar-permissions
-        name: Setup Datadog sidecar permissions
-        if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
-        run: |-
-          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      # - id: setup-datadog-cluster-agent
+      #   name: Setup Datadog cluster agent
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
+      #   run: |-
+      #     helm repo add datadog https://helm.datadoghq.com
+      #     helm repo update
+      #     helm upgrade datadog-agent datadog/datadog \
+      #       -f infra/datadog/cluster-agent-values.yaml \
+      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
+      #       --install
+
+      # - id: setup-datadog-sidecar-permissions
+      #   name: Setup Datadog sidecar permissions
+      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
+      #   run: |-
+      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -162,10 +162,85 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: test-if-statement-1
-        name: Testing if statement Cloudwatch
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
         run: |-
-          echo "Running for Cloudwatch"
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
+
+      - id: setup-cluster-cloudwatch-logging-policy
+        name: Setup permissions required for cluster to log to Cloudwatch
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }}"
+          name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
+          template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
+          no-fail-on-empty-changeset: "1"
+          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+
+      # Setting up log forwarding for pods hosted in EC2 nodes
+      - id: create-fluent-bit-namespace
+        name: Create namespace for node FluentBit deployment
+        run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
+
+      - id: create-service-account-for-node-fluent-bit
+        name: Create service account for node FluentBit
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          eksctl create iamserviceaccount \
+            --name fluent-bit \
+            --namespace node-logging \
+            --cluster biomage-$CLUSTER_ENV \
+            --role-name irsa-fluent-bit-$CLUSTER_ENV \
+            --attach-policy-arn $LOGGING_POLICY_ARN \
+            --override-existing-serviceaccounts \
+            --approve
+
+      - id: deploy-node-fluent-bit
+        name: Deploy FluentBit for EC2 nodes
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
+          # We do not want to log everything for costs/security concerns
+
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
+
+          kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
+
+      # Setting up log forwarding for pods hosted on Fargate nodes
+      - id: attach-pod-execution-role-name
+        name: Attach logging policy to pod execution role
+        env:
+          LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
+        run: |-
+          # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
+          # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
+          # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
+
+          POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
+            --cluster-name biomage-$CLUSTER_ENV \
+            --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
+
+          aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
+
+      - id: deploy-fargate-fluent-bit
+        name: Deploy FluentBit config for Fargate pods
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |-
+          # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+          yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
+
+          kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
 
   deploy-datadog-monitoring:
     name: Setup Datadog monitoring for deployment
@@ -197,118 +272,22 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: test-if-statement-2
-        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
-        name: Testing if statement Datadog
+      # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
+      - id: setup-datadog-cluster-agent
+        name: Setup Datadog cluster agent
         run: |-
-          echo "Running for Datadog"
+          helm repo add datadog https://helm.datadoghq.com
+          helm repo update
+          helm upgrade datadog-agent datadog/datadog \
+            -f infra/datadog/cluster-agent-values.yaml \
+            --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
+            --set datadog.clusterName=biomage-$CLUSTER_ENV \
+            --install
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
-
-      # - id: install-eksctl
-      #   name: Install eksctl
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   run: |-
-      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-      #     sudo mv /tmp/eksctl /usr/local/bin
-
-      # - id: setup-cluster-cloudwatch-logging-policy
-      #   name: Setup permissions required for cluster to log to Cloudwatch
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
-      #     name: "cluster-cloudwatch-logging-policy-${{ matrix.environment-type }}"
-      #     template: 'infra/cluster-logging/cf-cluster-log-cloudwatch-policy.yaml'
-      #     no-fail-on-empty-changeset: "1"
-      #     capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
-
-      # # Setting up log forwarding for pods hosted in EC2 nodes
-      # - id: create-fluent-bit-namespace
-      #   name: Create namespace for node FluentBit deployment
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
-
-      # - id: create-service-account-for-node-fluent-bit
-      #   name: Create service account for node FluentBit
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     eksctl create iamserviceaccount \
-      #       --name fluent-bit \
-      #       --namespace node-logging \
-      #       --cluster biomage-$CLUSTER_ENV \
-      #       --role-name irsa-fluent-bit-$CLUSTER_ENV \
-      #       --attach-policy-arn $LOGGING_POLICY_ARN \
-      #       --override-existing-serviceaccounts \
-      #       --approve
-
-      # - id: deploy-node-fluent-bit
-      #   name: Deploy FluentBit for EC2 nodes
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   env:
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #   run: |
-      #     # FluentBit configuration is determined in infra/cluster-logging/node-fluentbit-config.yaml, specifically under [INPUT] > Path
-      #     # We do not want to log everything for costs/security concerns
-
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/node-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/node-fluentbit-config.yaml
-
-      #     kubectl apply -f infra/cluster-logging/node-fluentbit-config.yaml
-
-      # # Setting up log forwarding for pods hosted on Fargate nodes
-      # - id: attach-pod-execution-role-name
-      #   name: Attach logging policy to pod execution role
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   env:
-      #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
-      #   run: |-
-      #     # Pods launched in the same cluster has the same pod execution role, as pod execution role scope is cluster-wide.
-      #     # See https://eksctl.io/usage/fargate-support/#creating-a-cluster-with-fargate-support
-      #     # Getting fargate-profile of pipeline or worker in the same cluster gets the same pod execution role.
-
-      #     POD_EXEC_ROLE_NAME=$(aws eks describe-fargate-profile \
-      #       --cluster-name biomage-$CLUSTER_ENV \
-      #       --fargate-profile-name pipeline-default | jq -r '.fargateProfile.podExecutionRoleArn' | awk -F"/" '{print (NF>1)? $NF : ""}' )
-
-      #     aws iam attach-role-policy --role-name $POD_EXEC_ROLE_NAME --policy-arn $LOGGING_POLICY_ARN
-
-      # - id: deploy-fargate-fluent-bit
-      #   name: Deploy FluentBit config for Fargate pods
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
-      #   env:
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #   run: |-
-      #     # FluentBit configuration is determined in infra/cluster-logging/fargate-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_CLUSTER_ENV\", \"$CLUSTER_ENV\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-      #     yq -i "(.. | select(type == \"!!str\")) |= sub(\"CI_AWS_REGION\", \"$AWS_REGION\")" infra/cluster-logging/fargate-fluentbit-config.yaml
-
-      #     kubectl apply -f infra/cluster-logging/fargate-fluentbit-config.yaml
-
-      # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
-      # - id: setup-datadog-cluster-agent
-      #   name: Setup Datadog cluster agent
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
-      #   run: |-
-      #     helm repo add datadog https://helm.datadoghq.com
-      #     helm repo update
-      #     helm upgrade datadog-agent datadog/datadog \
-      #       -f infra/datadog/cluster-agent-values.yaml \
-      #       --set datadog.apiKey=${{ secrets.DATADOG_API_KEY }} \
-      #       --set datadog.clusterName=biomage-$CLUSTER_ENV \
-      #       --install
-
-      # - id: setup-datadog-sidecar-permissions
-      #   name: Setup Datadog sidecar permissions
-      #   if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
-      #   run: |-
-      #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
+      - id: setup-datadog-sidecar-permissions
+        name: Setup Datadog sidecar permissions
+        run: |-
+          kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -114,7 +114,7 @@ jobs:
 
       - id: check-datadog-secrets
         name: Check if necessary Datadog secrets are installed.
-        if: ${{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
+        if: ${{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
         run: |-
           echo Checking if Datadog secrets are defined in the repository.
 
@@ -168,20 +168,20 @@ jobs:
 
       # - id: add-kubeconfig
       #   name: Add k8s config file for existing cluster.
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   run: |-
       #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
       # - id: install-eksctl
       #   name: Install eksctl
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   run: |-
       #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
       #     sudo mv /tmp/eksctl /usr/local/bin
 
       # - id: setup-cluster-cloudwatch-logging-policy
       #   name: Setup permissions required for cluster to log to Cloudwatch
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   uses: aws-actions/aws-cloudformation-github-deploy@v1
       #   with:
       #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
@@ -193,12 +193,12 @@ jobs:
       # # Setting up log forwarding for pods hosted in EC2 nodes
       # - id: create-fluent-bit-namespace
       #   name: Create namespace for node FluentBit deployment
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   run: kubectl apply -f infra/cluster-logging/node-fluentbit-namespace.yaml
 
       # - id: create-service-account-for-node-fluent-bit
       #   name: Create service account for node FluentBit
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
       #   run: |-
@@ -213,7 +213,7 @@ jobs:
 
       # - id: deploy-node-fluent-bit
       #   name: Deploy FluentBit for EC2 nodes
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     AWS_REGION: ${{ secrets.AWS_REGION }}
       #   run: |
@@ -228,7 +228,7 @@ jobs:
       # # Setting up log forwarding for pods hosted on Fargate nodes
       # - id: attach-pod-execution-role-name
       #   name: Attach logging policy to pod execution role
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     LOGGING_POLICY_ARN: ${{ steps.setup-cluster-cloudwatch-logging-policy.outputs.PolicyARN }}
       #   run: |-
@@ -244,7 +244,7 @@ jobs:
 
       # - id: deploy-fargate-fluent-bit
       #   name: Deploy FluentBit config for Fargate pods
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Cloudwatch" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Cloudwatch' }}
       #   env:
       #     AWS_REGION: ${{ secrets.AWS_REGION }}
       #   run: |-
@@ -257,7 +257,7 @@ jobs:
       # # Setting up Datadog to watch pod metrics for pods hosted on EC2 and Fargate nodes
       # - id: setup-datadog-cluster-agent
       #   name: Setup Datadog cluster agent
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
       #   run: |-
       #     helm repo add datadog https://helm.datadoghq.com
       #     helm repo update
@@ -269,7 +269,7 @@ jobs:
 
       # - id: setup-datadog-sidecar-permissions
       #   name: Setup Datadog sidecar permissions
-      #   if: {{ inputs.deployment_option == "all" || inputs.deployment_option == "Datadog" }}
+      #   if: {{ inputs.deployment_option == 'all' || inputs.deployment_option == 'Datadog' }}
       #   run: |-
       #     kubectl apply -f infra/datadog/datadog-sidecar-rbac.yaml
 

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -276,7 +276,7 @@ jobs:
   report-if-failed:
     name: Report if workflow failed
     runs-on: ubuntu-20.04
-    needs: [setup, deploy-monitoring]
+    needs: [set-environments, check-secrets, deploy-monitoring]
     if: failure() && github.ref == 'refs/heads/master'
     steps:
       - id: send-to-slack

--- a/.github/workflows/deploy-monitoring.yaml
+++ b/.github/workflows/deploy-monitoring.yaml
@@ -46,10 +46,6 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
-        environment-type: [production]
-        include:
-          - environment-name: Biomage
-            environment-type: staging
     environment: ${{ matrix.environment-name }}
     steps:
       - id: check-secrets
@@ -92,10 +88,10 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.all-envs) }}
-        environment-type: [production]
-        include:
-          - environment-name: Biomage
-            environment-type: staging
+        environment-type: [staging, production]
+        exclude:
+          - environment-name: trv
+            environment-type: production
     environment: ${{ matrix.environment-name }}
     steps:
       - id: checkout
@@ -201,10 +197,10 @@ jobs:
       max-parallel: 1
       matrix:
         environment-name: ${{ fromJson(needs.set-environments.outputs.datadog-envs) }}
-        environment-type: [production]
-        include:
-          - environment-name: Biomage
-            environment-type: staging
+        environment-type: [staging, production]
+        exclude:
+          - environment-name: trv
+            environment-type: production
     environment: ${{ matrix.environment-name }}
     steps:
       - id: check-datadog-secrets

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -1,8 +1,8 @@
 Biomage:
   publicFacing: true
+  monitoringEnabled: true
   selfSignedCertificate: false
-  datadogEnabled: true
 trv:
   publicFacing: false
+  monitoringEnabled: true
   selfSignedCertificate: true
-  datadogEnabled: true

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -4,5 +4,5 @@ Biomage:
   selfSignedCertificate: false
 trv:
   publicFacing: false
-  monitoringEnabled: true
+  monitoringEnabled: false
   selfSignedCertificate: true

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -4,5 +4,5 @@ Biomage:
   selfSignedCertificate: false
 trv:
   publicFacing: false
-  monitoringEnabled: false
+  monitoringEnabled: true
   selfSignedCertificate: true

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -1,8 +1,6 @@
 Biomage:
   publicFacing: true
-  monitoringEnabled: true
   selfSignedCertificate: false
 trv:
   publicFacing: false
-  monitoringEnabled: true
   selfSignedCertificate: true


### PR DESCRIPTION
# Background

**Tests:** 
1. Control works for all env names and types :
https://github.com/biomage-org/iac/actions/runs/3828323016
Setup logging and monitoring is run 3 times with the correct environment name, type and order (Biomage staging, Biomage production, trv production)

2. Deployment script runs:
https://github.com/biomage-org/iac/actions/runs/3828471669

4. Removing `monitoringEnabled` in `deploy-infra` works, correct metadata is created:
https://github.com/biomage-org/iac/actions/runs/3828390562
(Look at `Configure Kubernetes resrouces` > `Fill in account metadata`)

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR