### PR TITLE
[BIOMAGE-2290] - Comment out deploy route53 dns records

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -339,6 +339,8 @@ jobs:
           echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
           echo "::set-output name=domain-name::$DOMAIN_NAME"
 
+      # This is commented out because running Route53 for trv is still causing an error.
+      # A ticket to address this issue has been made into a ticket: BIOMAGE-2314. Refer to the ticket for more information.
       # - id: deploy-route53
       #   name: Deploy Route 53 DNS records to ELB
       #   uses: aws-actions/aws-cloudformation-github-deploy@v1

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -340,7 +340,7 @@ jobs:
           echo "::set-output name=domain-name::$DOMAIN_NAME"
 
       # This is commented out because running Route53 for trv is still causing an error.
-      # A ticket to address this issue has been made into a ticket: BIOMAGE-2314. Refer to the ticket for more information.
+      # A ticket to address this issue has been made: BIOMAGE-2314. Refer to the ticket for more information.
       # - id: deploy-route53
       #   name: Deploy Route 53 DNS records to ELB
       #   uses: aws-actions/aws-cloudformation-github-deploy@v1

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -339,14 +339,14 @@ jobs:
           echo "::set-output name=primary-domain-name::$PRIMARY_DOMAIN_NAME"
           echo "::set-output name=domain-name::$DOMAIN_NAME"
 
-      - id: deploy-route53
-        name: Deploy Route 53 DNS records to ELB
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }},DNSName=${{ steps.deploy-env-loadbalancer.outputs.DNSName }},HostedZoneId=${{ steps.deploy-env-loadbalancer.outputs.CanonicalHostedZoneID }},PrimaryDomainName=${{ steps.setup-domain.outputs.primary-domain-name }},DomainName=${{ steps.setup-domain.outputs.domain-name }}"
-          name: "biomage-alb-route53-${{ matrix.environment-type }}"
-          template: 'infra/cf-route53.yaml'
-          no-fail-on-empty-changeset: "1"
+      # - id: deploy-route53
+      #   name: Deploy Route 53 DNS records to ELB
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }},DNSName=${{ steps.deploy-env-loadbalancer.outputs.DNSName }},HostedZoneId=${{ steps.deploy-env-loadbalancer.outputs.CanonicalHostedZoneID }},PrimaryDomainName=${{ steps.setup-domain.outputs.primary-domain-name }},DomainName=${{ steps.setup-domain.outputs.domain-name }}"
+      #     name: "biomage-alb-route53-${{ matrix.environment-type }}"
+      #     template: 'infra/cf-route53.yaml'
+      #     no-fail-on-empty-changeset: "1"
 
       - id: deploy-xray-daemon
         name: Deploy AWS X-Ray daemon

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -3,4 +3,4 @@ Biomage:
   monitoringEnabled: true
 trv:
   publicFacing: false
-  monitoringEnabled: false
+  monitoringEnabled: true


### PR DESCRIPTION
# Background
Deploying Route 53 to the Flare deployment is still causing in an error. This blocks the completion of ticket [2290]((https://biomage.atlassian.net/browse/BIOMAGE-2290)). A separate [ticket 2314](https://biomage.atlassian.net/browse/BIOMAGE-2314) has been opened to address this issue.

For now, the required changes when configuring the cluster (adding `publicFacing` to the ConfigMap) will be done manually so that the rest of ticket 2290 (IAC PR #88) can be done.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2290

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
#88

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
N/A

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR