### PR TITLE
[BIOMAGE-2343] - Add deployment name env to pod

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -251,63 +251,63 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # - id: add-kubeconfig
-      #   name: Add k8s config file for existing cluster.
-      #   run: |-
-      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      # - id: deploy-metrics-server
-      #   name: Deploy k8s metrics server
-      #   run: |-
-      #     kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+      - id: deploy-metrics-server
+        name: Deploy k8s metrics server
+        run: |-
+          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 
-      # - id: install-helm
-      #   name: Install Helm
-      #   run: |-
-      #     sudo snap install helm --classic
+      - id: install-helm
+        name: Install Helm
+        run: |-
+          sudo snap install helm --classic
 
-      # - id: install-eksctl
-      #   name: Install eksctl
-      #   run: |-
-      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-      #     sudo mv /tmp/eksctl /usr/local/bin
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
 
-      # - id: deploy-load-balancer-role
-      #   name: Deploy permissions for AWS load balancer controller
-      #   run: |-
-      #     curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
-      #     aws iam create-policy \
-      #       --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-      #       --policy-document file://iam-policy.json || true
-      #     eksctl create iamserviceaccount \
-      #       --cluster=biomage-$CLUSTER_ENV \
-      #       --namespace=kube-system \
-      #       --name=aws-load-balancer-controller \
-      #       --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-      #       --override-existing-serviceaccounts \
-      #       --approve
+      - id: deploy-load-balancer-role
+        name: Deploy permissions for AWS load balancer controller
+        run: |-
+          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+          aws iam create-policy \
+            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --policy-document file://iam-policy.json || true
+          eksctl create iamserviceaccount \
+            --cluster=biomage-$CLUSTER_ENV \
+            --namespace=kube-system \
+            --name=aws-load-balancer-controller \
+            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --override-existing-serviceaccounts \
+            --approve
 
       # we need to retry this due to an active issue with the AWS Load Balancer Controller
       # where there are intermittent failures that are only fixable by retrying
       # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
-      # - id: install-lbc
-      #   name: Deploy AWS Load Balancer Controller
-      #   uses: nick-invision/retry@v2
-      #   with:
-      #     timeout_seconds: 600
-      #     max_attempts: 20
-      #     retry_on: error
-      #     on_retry_command: sleep $(shuf -i 5-15 -n 1)
-      #     command: |-
-      #       helm repo add eks https://aws.github.io/eks-charts
-      #       kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
-      #       helm repo update
-      #       helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
-      #         --namespace kube-system \
-      #         --set serviceAccount.create=false \
-      #         --set serviceAccount.name=aws-load-balancer-controller \
-      #         --set clusterName=biomage-$CLUSTER_ENV \
-      #         --install --wait
+      - id: install-lbc
+        name: Deploy AWS Load Balancer Controller
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 600
+          max_attempts: 20
+          retry_on: error
+          on_retry_command: sleep $(shuf -i 5-15 -n 1)
+          command: |-
+            helm repo add eks https://aws.github.io/eks-charts
+            kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+            helm repo update
+            helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+              --namespace kube-system \
+              --set serviceAccount.create=false \
+              --set serviceAccount.name=aws-load-balancer-controller \
+              --set clusterName=biomage-$CLUSTER_ENV \
+              --install --wait
 
       - id: platform-public-facing
         name: Get config for whether platform should be public facing
@@ -317,36 +317,36 @@ jobs:
         env:
           ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      # - id: install-elb-503-subscription-endpoint
-      #   name: Install ELB 503 subscription endpoint
-      #   run: |-
-      #       echo "value of publicFacing: $PUBLIC_FACING"
+      - id: install-elb-503-subscription-endpoint
+        name: Install ELB 503 subscription endpoint
+        run: |-
+            echo "value of publicFacing: $PUBLIC_FACING"
 
-      #       # Check that publicFacing is set to true or false
-      #       if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
-      #         echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
-      #         exit 1
-      #       fi
+            # Check that publicFacing is set to true or false
+            if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
+              echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
+              exit 1
+            fi
 
-      #       # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
-      #       # API staging environments because their endpoints are not yet available.
-      #       helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
-      #         --namespace default \
-      #         --set clusterEnv=$CLUSTER_ENV \
-      #         --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
-      #         --set-string publicFacing="$PUBLIC_FACING" \
-      #         --install --wait
-      #   env:
-      #     PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
+            # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
+            # API staging environments because their endpoints are not yet available.
+            helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
+              --namespace default \
+              --set clusterEnv=$CLUSTER_ENV \
+              --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
+              --set-string publicFacing="$PUBLIC_FACING" \
+              --install --wait
+        env:
+          PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
 
-      # - id: deploy-env-loadbalancer
-      #   name: Deploy AWS Application Load Balancer for environment
-      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
-      #     name: "biomage-k8s-alb-${{ matrix.environment-type }}"
-      #     template: 'infra/cf-loadbalancer.yaml'
-      #     no-fail-on-empty-changeset: "1"
+      - id: deploy-env-loadbalancer
+        name: Deploy AWS Application Load Balancer for environment
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
+          name: "biomage-k8s-alb-${{ matrix.environment-type }}"
+          template: 'infra/cf-loadbalancer.yaml'
+          no-fail-on-empty-changeset: "1"
 
       - id: setup-domain
         name: Compile environment-specific domain name
@@ -373,80 +373,80 @@ jobs:
       #     template: 'infra/cf-route53.yaml'
       #     no-fail-on-empty-changeset: "1"
 
-      # - id: deploy-xray-daemon
-      #   name: Deploy AWS X-Ray daemon
-      #   run: |-
-      #     helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
-      #       --namespace default \
-      #       --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
-      #       --install --wait
+      - id: deploy-xray-daemon
+        name: Deploy AWS X-Ray daemon
+        run: |-
+          helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
+            --namespace default \
+            --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
+            --install --wait
 
-      # - id: install-ebs-csi-driver
-      #   name: Install AWS EBS Container Storage Interface (CSI) drivers
-      #   run: |-
-      #     helm upgrade \
-      #       aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
-      #       --namespace kube-system \
-      #       --set enableVolumeScheduling=true \
-      #       --set enableVolumeResizing=true \
-      #       --set enableVolumeSnapshot=true \
-      #       --install --wait \
+      - id: install-ebs-csi-driver
+        name: Install AWS EBS Container Storage Interface (CSI) drivers
+        run: |-
+          helm upgrade \
+            aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
+            --namespace kube-system \
+            --set enableVolumeScheduling=true \
+            --set enableVolumeResizing=true \
+            --set enableVolumeSnapshot=true \
+            --install --wait \
 
-      # - id: deploy-read-only-group
-      #   name: Deploy read-only permission definition for cluster
-      #   run: |-
-      #     helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
-      #       --install --wait
+      - id: deploy-read-only-group
+        name: Deploy read-only permission definition for cluster
+        run: |-
+          helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
+            --install --wait
 
-      # - id: deploy-state-machine-role
-      #   name: Deploy AWS Step Function (state machine) roles
-      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
-      #   with:
-      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
-      #     name: "biomage-state-machine-role-${{ matrix.environment-type }}"
-      #     template: 'infra/cf-state-machine-role.yaml'
-      #     capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
-      #     no-fail-on-empty-changeset: "1"
+      - id: deploy-state-machine-role
+        name: Deploy AWS Step Function (state machine) roles
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment-type }}"
+          name: "biomage-state-machine-role-${{ matrix.environment-type }}"
+          template: 'infra/cf-state-machine-role.yaml'
+          capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
+          no-fail-on-empty-changeset: "1"
 
-      # - id: remove-identitymappings
-      #   name: Remove all previous identity mappings for IAM users
-      #   run: |-
-      #     eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
-      #     jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
-      #     while IFS= read -r user
-      #     do
-      #       echo "Remove rights of $user"
-      #       eksctl delete iamidentitymapping \
-      #         --cluster=biomage-$CLUSTER_ENV \
-      #         --arn $user \
-      #         --all
-      #     done < "/tmp/users_to_remove"
+      - id: remove-identitymappings
+        name: Remove all previous identity mappings for IAM users
+        run: |-
+          eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
+          jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
+          while IFS= read -r user
+          do
+            echo "Remove rights of $user"
+            eksctl delete iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn $user \
+              --all
+          done < "/tmp/users_to_remove"
 
       # see https://eksctl.io/usage/iam-identity-mappings/
-      # - id: add-state-machine-role
-      #   name: Grant rights to the state machine IAM role.
-      #   run: |-
-      #     eksctl create iamidentitymapping \
-      #       --cluster=biomage-$CLUSTER_ENV \
-      #       --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
-      #       --group state-machine-runner-group \
-      #       --username state-machine-runner
+      - id: add-state-machine-role
+        name: Grant rights to the state machine IAM role.
+        run: |-
+          eksctl create iamidentitymapping \
+            --cluster=biomage-$CLUSTER_ENV \
+            --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
+            --group state-machine-runner-group \
+            --username state-machine-runner
 
       # see https://eksctl.io/usage/iam-identity-mappings/
       # NOTE: after updating this step, make sure you apply the updates in other relevant Github Actions workflows
-      # - id: update-identitymapping-admin
-      #   name: Add cluster admin rights to everyone on the admin list.
-      #   run: |-
-      #     echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
-      #     while IFS= read -r user
-      #     do
-      #       echo "Adding cluster admin rights to $user"
-      #       eksctl create iamidentitymapping \
-      #         --cluster=biomage-$CLUSTER_ENV \
-      #         --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
-      #         --group system:masters \
-      #         --username $user
-      #     done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+      - id: update-identitymapping-admin
+        name: Add cluster admin rights to everyone on the admin list.
+        run: |-
+          echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+          while IFS= read -r user
+          do
+            echo "Adding cluster admin rights to $user"
+            eksctl create iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
+              --group system:masters \
+              --username $user
+          done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
 
       ###
       ### INSTALL AND CONFIGURE FLUX V2 ###
@@ -488,123 +488,123 @@ jobs:
           PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
           SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
 
-      # - id: create-flux-namespace
-      #   name: Attempt to create flux namespace
-      #   continue-on-error: true
-      #   run: |-
-      #     kubectl create namespace flux-system
+      - id: create-flux-namespace
+        name: Attempt to create flux namespace
+        continue-on-error: true
+        run: |-
+          kubectl create namespace flux-system
 
-      # - id: create-account-information-configmap
-      #   name: Create a configmap containing AWS account specific details
-      #   continue-on-error: false
-      #   run: |-
-      #     kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
+      - id: create-account-information-configmap
+        name: Create a configmap containing AWS account specific details
+        continue-on-error: false
+        run: |-
+          kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
 
-      # - id: install-flux-v2
-      #   name: Install flux CLI
-      #   run: |-
-      #     curl -s https://fluxcd.io/install.sh | sudo bash
+      - id: install-flux-v2
+        name: Install flux CLI
+        run: |-
+          curl -s https://fluxcd.io/install.sh | sudo bash
 
-      # - id: delete-old-flux-github-deploy-key
-      #   name: Attempt to delete previous github flux deploy key
-      #   continue-on-error: true
-      #   run: |-
-      #     kubectl -n flux-system delete secret flux-system
+      - id: delete-old-flux-github-deploy-key
+        name: Attempt to delete previous github flux deploy key
+        continue-on-error: true
+        run: |-
+          kubectl -n flux-system delete secret flux-system
 
-      # - id: install-flux
-      #   name: Install Flux to EKS cluster
-      #   run: |-
+      - id: install-flux
+        name: Install Flux to EKS cluster
+        run: |-
 
-      #     FLUX_REPO=releases
-      #     FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
-      #     REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
+          FLUX_REPO=releases
+          FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
+          REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
 
-      #     echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
-      #     echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
+          echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
+          echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
 
-      #     args=(
-      #       --owner $GITHUB_REPOSITORY_OWNER
-      #       --repository $FLUX_REPO
-      #       --branch master
-      #       --path $FLUX_PATH
-      #       --timeout 40s
-      #       –-interval 2m
-      #       --components-extra=image-reflector-controller,image-automation-controller
-      #       --namespace flux-system
-      #       --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-      #       --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-      #     )
+          args=(
+            --owner $GITHUB_REPOSITORY_OWNER
+            --repository $FLUX_REPO
+            --branch master
+            --path $FLUX_PATH
+            --timeout 40s
+            –-interval 2m
+            --components-extra=image-reflector-controller,image-automation-controller
+            --namespace flux-system
+            --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+            --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+          )
 
-      #     if [ "${{ matrix.environment-type }}" = "staging" ]
-      #     then
-      #       echo Flux will be deployed in staging with read and write permissions
-      #       args+=(--read-write-key)
-      #     elif [ "${{ matrix.environment-type }}" = "production" ]
-      #     then
-      #       echo Flux will be deployed in production with read-only permissions
-      #     fi
+          if [ "${{ matrix.environment-type }}" = "staging" ]
+          then
+            echo Flux will be deployed in staging with read and write permissions
+            args+=(--read-write-key)
+          elif [ "${{ matrix.environment-type }}" = "production" ]
+          then
+            echo Flux will be deployed in production with read-only permissions
+          fi
 
-      #     flux bootstrap github "${args[@]}"
+          flux bootstrap github "${args[@]}"
 
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
-      #     AWS_REGION: ${{ secrets.AWS_REGION }}
-      #     AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
-      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
+          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      # - id: fill-in-sync-yaml
-      #   name: Create the sync.yaml file that contains the Kustomization to sync the cluster
-      #   run: |-
-      #     export SPEC_PATH="./$CLUSTER_ENV"
-      #     yq -i '
-      #       .spec.path = strenv(SPEC_PATH)
-      #     ' infra/flux/sync.yaml
+      - id: fill-in-sync-yaml
+        name: Create the sync.yaml file that contains the Kustomization to sync the cluster
+        run: |-
+          export SPEC_PATH="./$CLUSTER_ENV"
+          yq -i '
+            .spec.path = strenv(SPEC_PATH)
+          ' infra/flux/sync.yaml
 
-      #     cat infra/flux/sync.yaml
+          cat infra/flux/sync.yaml
 
-      # - id: push-sync-yaml
-      #   name: Push the sync.yaml file that was filled in during the previous step
-      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #   with:
-      #     source_file: infra/flux/sync.yaml
-      #     destination_repo: ${{ env.flux-full-repo }}
-      #     destination_folder: ${{ env.flux-path }}
-      #     user_email: ci@biomage.net
-      #     user_name: 'Biomage CI/CD'
+      - id: push-sync-yaml
+        name: Push the sync.yaml file that was filled in during the previous step
+        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: infra/flux/sync.yaml
+          destination_repo: ${{ env.flux-full-repo }}
+          destination_folder: ${{ env.flux-path }}
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'
 
-      # - id: push-kustomization-yaml
-      #   name: Push the kustomization.yaml file to apply our custom config
-      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #   with:
-      #     source_file: infra/flux/kustomization.yaml
-      #     destination_repo: ${{ env.flux-full-repo }}
-      #     destination_folder: ${{ env.flux-path }}/flux-system
-      #     user_email: ci@biomage.net
-      #     user_name: 'Biomage CI/CD'
+      - id: push-kustomization-yaml
+        name: Push the kustomization.yaml file to apply our custom config
+        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source_file: infra/flux/kustomization.yaml
+          destination_repo: ${{ env.flux-full-repo }}
+          destination_folder: ${{ env.flux-path }}/flux-system
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'
 
-      # - id: install-kubernetes-reflector
-      #   name: Install kubernetes reflector
-      #   run: |-
-      #     helm repo add emberstack https://emberstack.github.io/helm-charts
-      #     helm repo update
-      #     helm upgrade --install reflector emberstack/reflector --namespace flux-system
+      - id: install-kubernetes-reflector
+        name: Install kubernetes reflector
+        run: |-
+          helm repo add emberstack https://emberstack.github.io/helm-charts
+          helm repo update
+          helm upgrade --install reflector emberstack/reflector --namespace flux-system
 
-      # - id: add-account-config-configmap-annotations
-      #   name: Add annotations to account-config configmap
-      #   run: |-
-      #     kubectl annotate configmap account-config \
-      #       --overwrite \
-      #       --namespace flux-system \
-      #       reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
-      #       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
-      #       reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
-      # ###
-      # ### END OF INSTALL AND CONFIGURE FLUX V2 ###
-      # ###
+      - id: add-account-config-configmap-annotations
+        name: Add annotations to account-config configmap
+        run: |-
+          kubectl annotate configmap account-config \
+            --overwrite \
+            --namespace flux-system \
+            reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+            reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
+            reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
+      ###
+      ### END OF INSTALL AND CONFIGURE FLUX V2 ###
+      ###
 
   report-if-failed:
     name: Report if workflow failed

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -464,8 +464,10 @@ jobs:
         run: |-
           export DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
           export DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
+          export DEPLOYMENT_NAME="${{ matrix.environment-name }}-${{ matrix.environment-type }}"
 
           yq -i '
+            .myAccount.deploymentName = strenv(DEPLOYMENT_NAME) |
             .myAccount.domainName = strenv(DOMAIN_NAME) |
             .myAccount.region = strenv(AWS_REGION) |
             .myAccount.accountId = strenv(AWS_ACCOUNT_ID) |

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -251,63 +251,63 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - id: add-kubeconfig
-        name: Add k8s config file for existing cluster.
-        run: |-
-          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+      # - id: add-kubeconfig
+      #   name: Add k8s config file for existing cluster.
+      #   run: |-
+      #     aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
 
-      - id: deploy-metrics-server
-        name: Deploy k8s metrics server
-        run: |-
-          kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+      # - id: deploy-metrics-server
+      #   name: Deploy k8s metrics server
+      #   run: |-
+      #     kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 
-      - id: install-helm
-        name: Install Helm
-        run: |-
-          sudo snap install helm --classic
+      # - id: install-helm
+      #   name: Install Helm
+      #   run: |-
+      #     sudo snap install helm --classic
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
+      # - id: install-eksctl
+      #   name: Install eksctl
+      #   run: |-
+      #     curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+      #     sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: deploy-load-balancer-role
-        name: Deploy permissions for AWS load balancer controller
-        run: |-
-          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
-          aws iam create-policy \
-            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --policy-document file://iam-policy.json || true
-          eksctl create iamserviceaccount \
-            --cluster=biomage-$CLUSTER_ENV \
-            --namespace=kube-system \
-            --name=aws-load-balancer-controller \
-            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --override-existing-serviceaccounts \
-            --approve
+      # - id: deploy-load-balancer-role
+      #   name: Deploy permissions for AWS load balancer controller
+      #   run: |-
+      #     curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+      #     aws iam create-policy \
+      #       --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+      #       --policy-document file://iam-policy.json || true
+      #     eksctl create iamserviceaccount \
+      #       --cluster=biomage-$CLUSTER_ENV \
+      #       --namespace=kube-system \
+      #       --name=aws-load-balancer-controller \
+      #       --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+      #       --override-existing-serviceaccounts \
+      #       --approve
 
       # we need to retry this due to an active issue with the AWS Load Balancer Controller
       # where there are intermittent failures that are only fixable by retrying
       # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
-      - id: install-lbc
-        name: Deploy AWS Load Balancer Controller
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 600
-          max_attempts: 20
-          retry_on: error
-          on_retry_command: sleep $(shuf -i 5-15 -n 1)
-          command: |-
-            helm repo add eks https://aws.github.io/eks-charts
-            kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
-            helm repo update
-            helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
-              --namespace kube-system \
-              --set serviceAccount.create=false \
-              --set serviceAccount.name=aws-load-balancer-controller \
-              --set clusterName=biomage-$CLUSTER_ENV \
-              --install --wait
+      # - id: install-lbc
+      #   name: Deploy AWS Load Balancer Controller
+      #   uses: nick-invision/retry@v2
+      #   with:
+      #     timeout_seconds: 600
+      #     max_attempts: 20
+      #     retry_on: error
+      #     on_retry_command: sleep $(shuf -i 5-15 -n 1)
+      #     command: |-
+      #       helm repo add eks https://aws.github.io/eks-charts
+      #       kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+      #       helm repo update
+      #       helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
+      #         --namespace kube-system \
+      #         --set serviceAccount.create=false \
+      #         --set serviceAccount.name=aws-load-balancer-controller \
+      #         --set clusterName=biomage-$CLUSTER_ENV \
+      #         --install --wait
 
       - id: platform-public-facing
         name: Get config for whether platform should be public facing
@@ -317,36 +317,36 @@ jobs:
         env:
           ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      - id: install-elb-503-subscription-endpoint
-        name: Install ELB 503 subscription endpoint
-        run: |-
-            echo "value of publicFacing: $PUBLIC_FACING"
+      # - id: install-elb-503-subscription-endpoint
+      #   name: Install ELB 503 subscription endpoint
+      #   run: |-
+      #       echo "value of publicFacing: $PUBLIC_FACING"
 
-            # Check that publicFacing is set to true or false
-            if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
-              echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
-              exit 1
-            fi
+      #       # Check that publicFacing is set to true or false
+      #       if [ "$PUBLIC_FACING" != "true" ] && [ "$PUBLIC_FACING" != "false" ]; then
+      #         echo "value of publicFacing in infra/config/github-environments-config.yaml is not set to true or false"
+      #         exit 1
+      #       fi
 
-            # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
-            # API staging environments because their endpoints are not yet available.
-            helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
-              --namespace default \
-              --set clusterEnv=$CLUSTER_ENV \
-              --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
-              --set-string publicFacing="$PUBLIC_FACING" \
-              --install --wait
-        env:
-          PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
+      #       # this is needed so SNS does not stop trying to subscribe to not-yet-deployed
+      #       # API staging environments because their endpoints are not yet available.
+      #       helm upgrade aws-elb-503-subscription-endpoint infra/aws-elb-503-subscription-endpoint \
+      #         --namespace default \
+      #         --set clusterEnv=$CLUSTER_ENV \
+      #         --set acmCertificate=${{ secrets.ACM_CERTIFICATE_ARN }} \
+      #         --set-string publicFacing="$PUBLIC_FACING" \
+      #         --install --wait
+      #   env:
+      #     PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
 
-      - id: deploy-env-loadbalancer
-        name: Deploy AWS Application Load Balancer for environment
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
-          name: "biomage-k8s-alb-${{ matrix.environment-type }}"
-          template: 'infra/cf-loadbalancer.yaml'
-          no-fail-on-empty-changeset: "1"
+      # - id: deploy-env-loadbalancer
+      #   name: Deploy AWS Application Load Balancer for environment
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }},PublicFacing=${{ steps.platform-public-facing.outputs.result }}"
+      #     name: "biomage-k8s-alb-${{ matrix.environment-type }}"
+      #     template: 'infra/cf-loadbalancer.yaml'
+      #     no-fail-on-empty-changeset: "1"
 
       - id: setup-domain
         name: Compile environment-specific domain name
@@ -373,80 +373,80 @@ jobs:
       #     template: 'infra/cf-route53.yaml'
       #     no-fail-on-empty-changeset: "1"
 
-      - id: deploy-xray-daemon
-        name: Deploy AWS X-Ray daemon
-        run: |-
-          helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
-            --namespace default \
-            --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
-            --install --wait
+      # - id: deploy-xray-daemon
+      #   name: Deploy AWS X-Ray daemon
+      #   run: |-
+      #     helm upgrade "aws-xray-daemon" infra/aws-xray-daemon \
+      #       --namespace default \
+      #       --set iamRole=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/xray-daemon-role-$CLUSTER_ENV \
+      #       --install --wait
 
-      - id: install-ebs-csi-driver
-        name: Install AWS EBS Container Storage Interface (CSI) drivers
-        run: |-
-          helm upgrade \
-            aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
-            --namespace kube-system \
-            --set enableVolumeScheduling=true \
-            --set enableVolumeResizing=true \
-            --set enableVolumeSnapshot=true \
-            --install --wait \
+      # - id: install-ebs-csi-driver
+      #   name: Install AWS EBS Container Storage Interface (CSI) drivers
+      #   run: |-
+      #     helm upgrade \
+      #       aws-ebs-csi-driver https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.4/aws-ebs-csi-driver-2.6.4.tgz \
+      #       --namespace kube-system \
+      #       --set enableVolumeScheduling=true \
+      #       --set enableVolumeResizing=true \
+      #       --set enableVolumeSnapshot=true \
+      #       --install --wait \
 
-      - id: deploy-read-only-group
-        name: Deploy read-only permission definition for cluster
-        run: |-
-          helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
-            --install --wait
+      # - id: deploy-read-only-group
+      #   name: Deploy read-only permission definition for cluster
+      #   run: |-
+      #     helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
+      #       --install --wait
 
-      - id: deploy-state-machine-role
-        name: Deploy AWS Step Function (state machine) roles
-        uses: aws-actions/aws-cloudformation-github-deploy@v1
-        with:
-          parameter-overrides: "Environment=${{ matrix.environment-type }}"
-          name: "biomage-state-machine-role-${{ matrix.environment-type }}"
-          template: 'infra/cf-state-machine-role.yaml'
-          capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
-          no-fail-on-empty-changeset: "1"
+      # - id: deploy-state-machine-role
+      #   name: Deploy AWS Step Function (state machine) roles
+      #   uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #   with:
+      #     parameter-overrides: "Environment=${{ matrix.environment-type }}"
+      #     name: "biomage-state-machine-role-${{ matrix.environment-type }}"
+      #     template: 'infra/cf-state-machine-role.yaml'
+      #     capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
+      #     no-fail-on-empty-changeset: "1"
 
-      - id: remove-identitymappings
-        name: Remove all previous identity mappings for IAM users
-        run: |-
-          eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
-          jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
-          while IFS= read -r user
-          do
-            echo "Remove rights of $user"
-            eksctl delete iamidentitymapping \
-              --cluster=biomage-$CLUSTER_ENV \
-              --arn $user \
-              --all
-          done < "/tmp/users_to_remove"
+      # - id: remove-identitymappings
+      #   name: Remove all previous identity mappings for IAM users
+      #   run: |-
+      #     eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
+      #     jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
+      #     while IFS= read -r user
+      #     do
+      #       echo "Remove rights of $user"
+      #       eksctl delete iamidentitymapping \
+      #         --cluster=biomage-$CLUSTER_ENV \
+      #         --arn $user \
+      #         --all
+      #     done < "/tmp/users_to_remove"
 
       # see https://eksctl.io/usage/iam-identity-mappings/
-      - id: add-state-machine-role
-        name: Grant rights to the state machine IAM role.
-        run: |-
-          eksctl create iamidentitymapping \
-            --cluster=biomage-$CLUSTER_ENV \
-            --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
-            --group state-machine-runner-group \
-            --username state-machine-runner
+      # - id: add-state-machine-role
+      #   name: Grant rights to the state machine IAM role.
+      #   run: |-
+      #     eksctl create iamidentitymapping \
+      #       --cluster=biomage-$CLUSTER_ENV \
+      #       --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
+      #       --group state-machine-runner-group \
+      #       --username state-machine-runner
 
       # see https://eksctl.io/usage/iam-identity-mappings/
       # NOTE: after updating this step, make sure you apply the updates in other relevant Github Actions workflows
-      - id: update-identitymapping-admin
-        name: Add cluster admin rights to everyone on the admin list.
-        run: |-
-          echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
-          while IFS= read -r user
-          do
-            echo "Adding cluster admin rights to $user"
-            eksctl create iamidentitymapping \
-              --cluster=biomage-$CLUSTER_ENV \
-              --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
-              --group system:masters \
-              --username $user
-          done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+      # - id: update-identitymapping-admin
+      #   name: Add cluster admin rights to everyone on the admin list.
+      #   run: |-
+      #     echo "Reading cluster rights from file: infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
+      #     while IFS= read -r user
+      #     do
+      #       echo "Adding cluster admin rights to $user"
+      #       eksctl create iamidentitymapping \
+      #         --cluster=biomage-$CLUSTER_ENV \
+      #         --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
+      #         --group system:masters \
+      #         --username $user
+      #     done < "infra/config/cluster/${{matrix.environment-name}}/cluster-admins-$CLUSTER_ENV"
 
       ###
       ### INSTALL AND CONFIGURE FLUX V2 ###
@@ -488,123 +488,123 @@ jobs:
           PUBLIC_FACING: ${{ steps.platform-public-facing.outputs.result }}
           SELF_SIGNED_CERTIFICATE: ${{ steps.using-self-signed-certificate.outputs.result }}
 
-      - id: create-flux-namespace
-        name: Attempt to create flux namespace
-        continue-on-error: true
-        run: |-
-          kubectl create namespace flux-system
+      # - id: create-flux-namespace
+      #   name: Attempt to create flux namespace
+      #   continue-on-error: true
+      #   run: |-
+      #     kubectl create namespace flux-system
 
-      - id: create-account-information-configmap
-        name: Create a configmap containing AWS account specific details
-        continue-on-error: false
-        run: |-
-          kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
+      # - id: create-account-information-configmap
+      #   name: Create a configmap containing AWS account specific details
+      #   continue-on-error: false
+      #   run: |-
+      #     kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
 
-      - id: install-flux-v2
-        name: Install flux CLI
-        run: |-
-          curl -s https://fluxcd.io/install.sh | sudo bash
+      # - id: install-flux-v2
+      #   name: Install flux CLI
+      #   run: |-
+      #     curl -s https://fluxcd.io/install.sh | sudo bash
 
-      - id: delete-old-flux-github-deploy-key
-        name: Attempt to delete previous github flux deploy key
-        continue-on-error: true
-        run: |-
-          kubectl -n flux-system delete secret flux-system
+      # - id: delete-old-flux-github-deploy-key
+      #   name: Attempt to delete previous github flux deploy key
+      #   continue-on-error: true
+      #   run: |-
+      #     kubectl -n flux-system delete secret flux-system
 
-      - id: install-flux
-        name: Install Flux to EKS cluster
-        run: |-
+      # - id: install-flux
+      #   name: Install Flux to EKS cluster
+      #   run: |-
 
-          FLUX_REPO=releases
-          FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
-          REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
+      #     FLUX_REPO=releases
+      #     FLUX_PATH=deployments/$ENVIRONMENT_NAME-$CLUSTER_ENV
+      #     REPO_FULL_PATH=$GITHUB_REPOSITORY_OWNER/$FLUX_REPO
 
-          echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
-          echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
+      #     echo "flux-full-repo=$(echo $REPO_FULL_PATH)" >> $GITHUB_ENV
+      #     echo "flux-path=$(echo $FLUX_PATH)" >> $GITHUB_ENV
 
-          args=(
-            --owner $GITHUB_REPOSITORY_OWNER
-            --repository $FLUX_REPO
-            --branch master
-            --path $FLUX_PATH
-            --timeout 40s
-            –-interval 2m
-            --components-extra=image-reflector-controller,image-automation-controller
-            --namespace flux-system
-            --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-            --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
-          )
+      #     args=(
+      #       --owner $GITHUB_REPOSITORY_OWNER
+      #       --repository $FLUX_REPO
+      #       --branch master
+      #       --path $FLUX_PATH
+      #       --timeout 40s
+      #       –-interval 2m
+      #       --components-extra=image-reflector-controller,image-automation-controller
+      #       --namespace flux-system
+      #       --cluster arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+      #       --context arn:aws:eks:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/biomage-$CLUSTER_ENV
+      #     )
 
-          if [ "${{ matrix.environment-type }}" = "staging" ]
-          then
-            echo Flux will be deployed in staging with read and write permissions
-            args+=(--read-write-key)
-          elif [ "${{ matrix.environment-type }}" = "production" ]
-          then
-            echo Flux will be deployed in production with read-only permissions
-          fi
+      #     if [ "${{ matrix.environment-type }}" = "staging" ]
+      #     then
+      #       echo Flux will be deployed in staging with read and write permissions
+      #       args+=(--read-write-key)
+      #     elif [ "${{ matrix.environment-type }}" = "production" ]
+      #     then
+      #       echo Flux will be deployed in production with read-only permissions
+      #     fi
 
-          flux bootstrap github "${args[@]}"
+      #     flux bootstrap github "${args[@]}"
 
-        env:
-          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
-          ENVIRONMENT_NAME: ${{ matrix.environment-name }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+      #     AWS_REGION: ${{ secrets.AWS_REGION }}
+      #     AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
+      #     ENVIRONMENT_NAME: ${{ matrix.environment-name }}
 
-      - id: fill-in-sync-yaml
-        name: Create the sync.yaml file that contains the Kustomization to sync the cluster
-        run: |-
-          export SPEC_PATH="./$CLUSTER_ENV"
-          yq -i '
-            .spec.path = strenv(SPEC_PATH)
-          ' infra/flux/sync.yaml
+      # - id: fill-in-sync-yaml
+      #   name: Create the sync.yaml file that contains the Kustomization to sync the cluster
+      #   run: |-
+      #     export SPEC_PATH="./$CLUSTER_ENV"
+      #     yq -i '
+      #       .spec.path = strenv(SPEC_PATH)
+      #     ' infra/flux/sync.yaml
 
-          cat infra/flux/sync.yaml
+      #     cat infra/flux/sync.yaml
 
-      - id: push-sync-yaml
-        name: Push the sync.yaml file that was filled in during the previous step
-        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source_file: infra/flux/sync.yaml
-          destination_repo: ${{ env.flux-full-repo }}
-          destination_folder: ${{ env.flux-path }}
-          user_email: ci@biomage.net
-          user_name: 'Biomage CI/CD'
+      # - id: push-sync-yaml
+      #   name: Push the sync.yaml file that was filled in during the previous step
+      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #   with:
+      #     source_file: infra/flux/sync.yaml
+      #     destination_repo: ${{ env.flux-full-repo }}
+      #     destination_folder: ${{ env.flux-path }}
+      #     user_email: ci@biomage.net
+      #     user_name: 'Biomage CI/CD'
 
-      - id: push-kustomization-yaml
-        name: Push the kustomization.yaml file to apply our custom config
-        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source_file: infra/flux/kustomization.yaml
-          destination_repo: ${{ env.flux-full-repo }}
-          destination_folder: ${{ env.flux-path }}/flux-system
-          user_email: ci@biomage.net
-          user_name: 'Biomage CI/CD'
+      # - id: push-kustomization-yaml
+      #   name: Push the kustomization.yaml file to apply our custom config
+      #   uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #   with:
+      #     source_file: infra/flux/kustomization.yaml
+      #     destination_repo: ${{ env.flux-full-repo }}
+      #     destination_folder: ${{ env.flux-path }}/flux-system
+      #     user_email: ci@biomage.net
+      #     user_name: 'Biomage CI/CD'
 
-      - id: install-kubernetes-reflector
-        name: Install kubernetes reflector
-        run: |-
-          helm repo add emberstack https://emberstack.github.io/helm-charts
-          helm repo update
-          helm upgrade --install reflector emberstack/reflector --namespace flux-system
+      # - id: install-kubernetes-reflector
+      #   name: Install kubernetes reflector
+      #   run: |-
+      #     helm repo add emberstack https://emberstack.github.io/helm-charts
+      #     helm repo update
+      #     helm upgrade --install reflector emberstack/reflector --namespace flux-system
 
-      - id: add-account-config-configmap-annotations
-        name: Add annotations to account-config configmap
-        run: |-
-          kubectl annotate configmap account-config \
-            --overwrite \
-            --namespace flux-system \
-            reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
-            reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
-            reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
-      ###
-      ### END OF INSTALL AND CONFIGURE FLUX V2 ###
-      ###
+      # - id: add-account-config-configmap-annotations
+      #   name: Add annotations to account-config configmap
+      #   run: |-
+      #     kubectl annotate configmap account-config \
+      #       --overwrite \
+      #       --namespace flux-system \
+      #       reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+      #       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="ui-.*,api-.*,pipeline-.*,worker-.*" \
+      #       reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true"
+      # ###
+      # ### END OF INSTALL AND CONFIGURE FLUX V2 ###
+      # ###
 
   report-if-failed:
     name: Report if workflow failed

--- a/charts/nodejs/templates/deployment.yaml
+++ b/charts/nodejs/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             fieldRef:
               fieldPath: metadata.name
 
+        - name: DEPLOYMENT_NAME
+          value: {{ .Values.myAccount.deploymentName | quote }}
+
         - name: DOMAIN_NAME
           value: {{ .Values.myAccount.domainName | quote }}
 

--- a/infra/config/account-config.yaml
+++ b/infra/config/account-config.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 myAccount:
+  deploymentName: FILLED_IN_BY_CI
   domainName: FILLED_IN_BY_CI
   region: FILLED_IN_BY_CI
   accountId: FILLED_IN_BY_CI


### PR DESCRIPTION
# Background
We do not want to hardode account ids in the API repo, so we have to add the deployment name to the pods as env variables.

Tested filling the deployment name in run https://github.com/biomage-org/iac/actions/runs/3917691214
<img width="378" alt="image" src="https://user-images.githubusercontent.com/2862362/212463875-d6265a3a-b76f-4451-a997-451a7dea373e.png">


#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2343

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
https://github.com/biomage-org/api/pull/92

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR