### PR TITLE
[BIOMAGE-2296] - Add sandbox id to SNS export

### DIFF
--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -14,10 +14,10 @@ Parameters:
     Type: String
     Default: default
     Description: The sandbox ID of the environment that this topic is created for.
-
-
-Mappings:
-  SNSTopicName: !Sub "work-results-${Environment}-${SandboxID}-v2"
+  TopicName:
+    Type: String
+    Default: !Sub "work-results-${Environment}-${SandboxID}-v2"
+    Description: Name of the SNS topic
 
 Conditions:
   isProd: !Equals [!Ref Environment, "production"]
@@ -37,7 +37,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: "alias/aws/sns"
-      TopicName: !FindInMap SNSTopicName
+      TopicName: !Sub "${TopicName}"
   PipelineResultsSubscriptionV2:
     Type: 'AWS::SNS::Subscription'
     Properties:
@@ -88,4 +88,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !FindInMap SNSTopicName
+      Name: !Sub "${TopicName}"

--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -15,6 +15,10 @@ Parameters:
     Default: default
     Description: The sandbox ID of the environment that this topic is created for.
 
+
+Mappings:
+  SNSTopicName: !Sub "work-results-${Environment}-${SandboxID}-v2"
+
 Conditions:
   isProd: !Equals [!Ref Environment, "production"]
   isDev: !Equals [!Ref Environment, "development"]
@@ -33,7 +37,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: "alias/aws/sns"
-      TopicName: !Sub "work-results-${Environment}-${SandboxID}-v2"
+      TopicName: !FindInMap SNSTopicName
   PipelineResultsSubscriptionV2:
     Type: 'AWS::SNS::Subscription'
     Properties:
@@ -84,4 +88,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !Sub '${SNSTopicV2.TopicName}::ARN'
+      Name: !FindInMap SNSTopicName

--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -84,4 +84,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !Sub "work-results-${Environment}-${SandboxID}-v2::ARN"
+      Name: !Sub "sns-work-results-${Environment}-${SandboxID}-v2::ARN"

--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -84,4 +84,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !Sub 'sns-work-result-${Environment}-${SandboxID}-v2::ARN'
+      Name: !Sub '${SNSTopicV2.TopicName}::ARN'

--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -84,4 +84,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !Sub 'sns-work-result-${Environment}::ARN'
+      Name: !Sub 'sns-work-result-${Environment}-${SandboxID}::ARN'

--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -14,10 +14,6 @@ Parameters:
     Type: String
     Default: default
     Description: The sandbox ID of the environment that this topic is created for.
-  TopicName:
-    Type: String
-    Default: !Sub "work-results-${Environment}-${SandboxID}-v2"
-    Description: Name of the SNS topic
 
 Conditions:
   isProd: !Equals [!Ref Environment, "production"]
@@ -37,7 +33,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: "alias/aws/sns"
-      TopicName: !Sub "${TopicName}"
+      TopicName: !Sub "work-results-${Environment}-${SandboxID}-v2"
   PipelineResultsSubscriptionV2:
     Type: 'AWS::SNS::Subscription'
     Properties:
@@ -88,4 +84,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !Sub "${TopicName}"
+      Name: !Sub "work-results-${Environment}-${SandboxID}-v2::ARN"

--- a/cf/sns.yaml
+++ b/cf/sns.yaml
@@ -84,4 +84,4 @@ Outputs:
     Description: The ARN of the SNS v2 topic
     Value: !Ref SNSTopicV2
     Export:
-      Name: !Sub 'sns-work-result-${Environment}-${SandboxID}::ARN'
+      Name: !Sub 'sns-work-result-${Environment}-${SandboxID}-v2::ARN'


### PR DESCRIPTION
# Background
Staging environment CF is failing, complaining that the export name exists. This happens because the exported name in staging enviroments do not contain sandbox id to make it unique.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2296

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR