### PR TITLE
[2365] Add encryption to root ebs volumes

### DIFF
--- a/cf/rds-agent.yaml
+++ b/cf/rds-agent.yaml
@@ -63,10 +63,10 @@ Resources:
       IamInstanceProfile: !Ref SSMProfile
       ImageId: !Ref LatestAmiId
       BlockDeviceMappings:
-        - DeviceName: "/dev/sda1"
+        - DeviceName: "/dev/xvda"
           Ebs:
-            VolumeType: gp2
-            Encrypted: true
+            VolumeSize: '8'
+            Encrypted: 'true'
       SecurityGroupIds:
         - Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSAgentSecurityGroupId"
       SubnetId:

--- a/cf/rds-agent.yaml
+++ b/cf/rds-agent.yaml
@@ -62,6 +62,11 @@ Resources:
       InstanceType: t2.nano
       IamInstanceProfile: !Ref SSMProfile
       ImageId: !Ref LatestAmiId
+      BlockDeviceMappings:
+        - DeviceName: "/dev/sda1"
+          Ebs:
+            VolumeType: gp2
+            Encrypted: true
       SecurityGroupIds:
         - Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSAgentSecurityGroupId"
       SubnetId:


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2365

This replaces the current rds agents with new ones that have their root ebs volumes encrypted.

It was already ran for staging so it can be tried out.

Also going to ec2 in the aws console, looking at the rds agent for staging and clicking on the "storage" tab shows that the volume is encrypted now:
<img width="816" alt="image" src="https://user-images.githubusercontent.com/8465903/216360461-40957545-a37f-4c94-a4c1-33c06af925f8.png">

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR