### PR TITLE
Make deletion lambda take into account nested files

### DIFF
--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -110,7 +110,7 @@ Resources:
 
               items.map(items => console.log(`== Deleting ${items.Key} from ${bucketName} ==`));
               await s3Client.deleteObjects(deleteObjectParams).promise();
-              console.log(`== Successfully deleted files from ${bucketName}==`, data);
+              console.log(`== Successfully deleted files from ${bucketName}==`);
             } catch (err) {
               console.log(err, err.stack);
             }

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -73,40 +73,53 @@ Resources:
       Code:
         ZipFile: |
           const AWS = require('aws-sdk');
-
-          const deleteS3File = (key, bucketName) => {
-            const params = {
-              Bucket: bucketName,
-              Key: key,
-            };
-
-            const s3 = new AWS.S3({
+          const s3Client = new AWS.S3({
               apiVersion: '2006-03-01',
-            });
+          });
 
-            s3.deleteObject(params, (err) => {
-              if (err) {
-                console.log(err, err.stack);
-                return;
+          const deleteS3Files = async (key, bucketName) => {
+              const listObjectParams = {
+                  Bucket: bucketName,
+                  Prefix: key
+              };
+
+              try {
+                  // Get all files in case the objects are nested
+                  const { Contents: objects } = await s3Client
+                      .listObjectsV2(listObjectParams)
+                      .promise();
+
+                  const items = objects.map((object) => ({ Key: object.Key }));
+
+                  const deleteObjectParams = {
+                      Bucket: bucketName,
+                      Delete: {
+                          Objects: items // List of items to delete
+                      }
+                  };
+
+                  items.map(items => console.log(`== Deleting ${items.Key} from ${bucketName} ==`));
+
+                  s3Client.deleteObjects(deleteObjectParams, (err, data) => {
+                      if (err) console.log(err, err.stack);
+                      else console.log(`== Successfully deleted files from ${bucketName}==`, data);
+                  });
+              } catch (err) {
+                  console.log(err, err.stack);
               }
-              console.log(`== Successfully deleted ${key} from ${bucketName}==`);
-            });
           };
 
           exports.handler = async (event, context, callback) => {
-            const { key, bucketName } = event;
-            const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
+              const { key, bucketName } = event;
+              const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
 
-            console.log(`== Deleting ${key} from ${bucketName} ==`);
-            deleteS3File(key, realBucketName);
+              deleteS3Files(key, realBucketName);
 
-            callback(null, event);
+              callback(null, event);
           };
-
 
   LoggingGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/delete-s3-file-lambda-${Environment}"
       RetentionInDays: 1
-      

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -109,11 +109,8 @@ Resources:
               };
 
               items.map(items => console.log(`== Deleting ${items.Key} from ${bucketName} ==`));
-
-              s3Client.deleteObjects(deleteObjectParams, (err, data) => {
-                if (err) console.log(err, err.stack);
-                else console.log(`== Successfully deleted files from ${bucketName}==`, data);
-              });
+              await s3Client.deleteObjects(deleteObjectParams);
+              console.log(`== Successfully deleted files from ${bucketName}==`, data);
             } catch (err) {
               console.log(err, err.stack);
             }
@@ -122,8 +119,7 @@ Resources:
           exports.handler = async (event) => {
             const { key, bucketName } = event;
             const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
-
-            await deleteS3Files(key, realBucketName);
+            return deleteS3Files(key, realBucketName);
           };
 
   LoggingGroup:

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -74,48 +74,48 @@ Resources:
         ZipFile: |
           const AWS = require('aws-sdk');
           const s3Client = new AWS.S3({
-              apiVersion: '2006-03-01',
+            apiVersion: '2006-03-01',
           });
 
           const deleteS3Files = async (key, bucketName) => {
-              const listObjectParams = {
-                  Bucket: bucketName,
-                  Prefix: key
+            const listObjectParams = {
+              Bucket: bucketName,
+              Prefix: key
+            };
+
+            try {
+              // Get all files in case the objects are nested
+              const { Contents: objects } = await s3Client
+                .listObjectsV2(listObjectParams)
+                .promise();
+
+              const items = objects.map((object) => ({ Key: object.Key }));
+
+              const deleteObjectParams = {
+                Bucket: bucketName,
+                Delete: {
+                  Objects: items // List of items to delete
+                }
               };
 
-              try {
-                  // Get all files in case the objects are nested
-                  const { Contents: objects } = await s3Client
-                      .listObjectsV2(listObjectParams)
-                      .promise();
+              items.map(items => console.log(`== Deleting ${items.Key} from ${bucketName} ==`));
 
-                  const items = objects.map((object) => ({ Key: object.Key }));
-
-                  const deleteObjectParams = {
-                      Bucket: bucketName,
-                      Delete: {
-                          Objects: items // List of items to delete
-                      }
-                  };
-
-                  items.map(items => console.log(`== Deleting ${items.Key} from ${bucketName} ==`));
-
-                  s3Client.deleteObjects(deleteObjectParams, (err, data) => {
-                      if (err) console.log(err, err.stack);
-                      else console.log(`== Successfully deleted files from ${bucketName}==`, data);
-                  });
-              } catch (err) {
-                  console.log(err, err.stack);
-              }
+              s3Client.deleteObjects(deleteObjectParams, (err, data) => {
+                if (err) console.log(err, err.stack);
+                else console.log(`== Successfully deleted files from ${bucketName}==`, data);
+              });
+            } catch (err) {
+              console.log(err, err.stack);
+            }
           };
 
           exports.handler = async (event, context, callback) => {
-              const { key, bucketName } = event;
-              const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
+            const { key, bucketName } = event;
+            const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
 
-              deleteS3Files(key, realBucketName);
+            deleteS3Files(key, realBucketName);
 
-              callback(null, event);
+            callback(null, event);
           };
 
   LoggingGroup:

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -31,6 +31,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - 's3:DeleteObject'
+                  - 's3:ListBucket'
                 Resource:
                   - Fn::Sub: "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - Fn::Sub: "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -82,8 +82,8 @@ Resources:
           CLUSTER_ENV: !Ref Environment
       Code:
         ZipFile: |
+          const AWS = require('aws-sdk');
           const deleteS3Files = async (key, bucketName) => {
-            const AWS = require('aws-sdk');
             const s3Client = new AWS.S3({
               apiVersion: '2006-03-01',
             });

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -123,7 +123,7 @@ Resources:
             const { key, bucketName } = event;
             const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
 
-            deleteS3Files(key, realBucketName);
+            await deleteS3Files(key, realBucketName);
 
             callback(null, event);
           };

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -82,12 +82,12 @@ Resources:
           CLUSTER_ENV: !Ref Environment
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
-          const s3Client = new AWS.S3({
-            apiVersion: '2006-03-01',
-          });
-
           const deleteS3Files = async (key, bucketName) => {
+            const AWS = require('aws-sdk');
+            const s3Client = new AWS.S3({
+              apiVersion: '2006-03-01',
+            });
+
             const listObjectParams = {
               Bucket: bucketName,
               Prefix: key

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -109,7 +109,7 @@ Resources:
               };
 
               items.map(items => console.log(`== Deleting ${items.Key} from ${bucketName} ==`));
-              await s3Client.deleteObjects(deleteObjectParams);
+              await s3Client.deleteObjects(deleteObjectParams).promise();
               console.log(`== Successfully deleted files from ${bucketName}==`, data);
             } catch (err) {
               console.log(err, err.stack);

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -30,7 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 's3:DeleteObjects'
+                  - 's3:DeleteObject'
                 Resource:
                   - Fn::Sub: "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - Fn::Sub: "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -30,8 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 's3:DeleteObject'
-                  - 's3:ListBucket'
+                  - 's3:DeleteObjects'
                 Resource:
                   - Fn::Sub: "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - Fn::Sub: "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"
@@ -39,6 +38,16 @@ Resources:
                   - Fn::Sub: "arn:aws:s3:::biomage-filtered-cells-${Environment}-${AWS::AccountId}/*"
                   - Fn::Sub: "arn:aws:s3:::processed-matrix-${Environment}-${AWS::AccountId}/*"
                   - Fn::Sub: "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}/*"
+              - Effect: Allow
+                Action:
+                  - 's3:ListBucket'
+                Resource:
+                  - Fn::Sub: "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}"
+                  - Fn::Sub: "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}"
+                  - Fn::Sub: "arn:aws:s3:::plots-tables-${Environment}-${AWS::AccountId}"
+                  - Fn::Sub: "arn:aws:s3:::biomage-filtered-cells-${Environment}-${AWS::AccountId}"
+                  - Fn::Sub: "arn:aws:s3:::processed-matrix-${Environment}-${AWS::AccountId}"
+                  - Fn::Sub: "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}"
 
         - PolicyName: !Sub "can-create-log-group-in-cloudwatch-${Environment}"
           PolicyDocument:

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -119,13 +119,11 @@ Resources:
             }
           };
 
-          exports.handler = async (event, context, callback) => {
+          exports.handler = async (event) => {
             const { key, bucketName } = event;
             const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
 
-            await deleteS3Files(key, realBucketName);
-
-            callback(null, event);
+            return deleteS3Files(key, realBucketName);
           };
 
   LoggingGroup:

--- a/cf/delete-s3-file-lambda.yaml
+++ b/cf/delete-s3-file-lambda.yaml
@@ -123,7 +123,7 @@ Resources:
             const { key, bucketName } = event;
             const realBucketName = `${bucketName}-${process.env.CLUSTER_ENV}-${process.env.AWS_ACCOUNT_ID}`;
 
-            return deleteS3Files(key, realBucketName);
+            await deleteS3Files(key, realBucketName);
           };
 
   LoggingGroup:


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2083

#### Link to staging deployment URL 
N/A

#### Anything else the reviewers should know about the changes here
In the case of nested files (as shown in the image in the issue) the `delete-s3-file-lambda` recieves the folder that the objects are stored in as a key for the `DELETE` request. The files inside of the folder are never marked for deletion, thus their latest version remains the same and their lifecycle does not start elapsing.

The PR gets all the files that are prefixed with the folder name and sends a delete request for each of them. The latest version of each file is now the Delete Marker and their lifecycle starts.

_Note: Folders in S3 do not exist in the general sense, but they are just prefixes to files. S3 creates a 0-byte file with the same name as prefix to simulate a folder (this is how it handles empty folders). The reason why there was no error thrown when trying to delete the folder itself is because this 0-byte file got marked for deletion._ **These markers are important for the clean-up as they can help check which experiments need removal when cleaning up!!**

# Changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR