### PR TITLE
[2356] [2044] Remove v2 nodegroup

### DIFF
--- a/infra/config/cluster/cluster-template.yaml
+++ b/infra/config/cluster/cluster-template.yaml
@@ -27,16 +27,6 @@ iam:
 # if you add or remove items under managedNodeGroups, make sure you update customized cluster
 # config for each of the Github environments under infra/config/cluster
 managedNodeGroups:
-  - name: nodegroup-post-scaling-x86-v2
-    instanceType: r5.large
-    desiredCapacity: 2
-    minSize: 2
-    maxSize: 4
-    volumeSize: 80
-    iam:
-      withAddonPolicies:
-        ebs: true
-        autoScaler: true
   - name: nodegroup-post-scaling-x86-v3
     instanceType: r6i.large
     desiredCapacity: 2

--- a/infra/config/cluster/trv/custom-cluster-config.yaml
+++ b/infra/config/cluster/trv/custom-cluster-config.yaml
@@ -13,10 +13,6 @@ vpc:
         id: "subnet-09bccdc8be23d5402"
 
 managedNodeGroups:
-  - name: nodegroup-post-scaling-x86-v2
-    subnets:
-      - dmz-us-east-2a
-      - dmz-us-east-2b
   - name: nodegroup-post-scaling-x86-v3
     subnets:
       - dmz-us-east-2a


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2044
https://biomage.atlassian.net/browse/BIOMAGE-2365

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR