### PR TITLE
[2414] Fix deploy infra with create cluster

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -299,6 +299,7 @@ jobs:
             --namespace=kube-system \
             --name=aws-load-balancer-controller \
             --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --role-name eksctl-$CLUSTER_ENV-load-balancer-controller-role \
             --override-existing-serviceaccounts \
             --approve
 
@@ -322,6 +323,7 @@ jobs:
               --set serviceAccount.create=false \
               --set serviceAccount.name=aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
+              --set iam.serviceAccounts[2].roleName = eksctl-$CLUSTER_ENV-load-balancer-controller-role" \
               --install --wait
 
       - id: platform-public-facing

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -159,7 +159,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - id: fill-metadata
-        name: Add name and region dependent params to the eksctl config.
+        name: Add name and region to the eksctl file.
         run: |-
           export CLUSTER_NAME="biomage-$CLUSTER_ENV"
 
@@ -323,7 +323,6 @@ jobs:
               --set serviceAccount.create=false \
               --set serviceAccount.name=aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
-              --set iam.serviceAccounts[2].roleName = eksctl-$CLUSTER_ENV-load-balancer-controller-role" \
               --install --wait
 
       - id: platform-public-facing

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -233,8 +233,8 @@ jobs:
         if: steps.create-clusters.outcome == 'failure' && steps.check-for-failure.outputs.reason == 'already-exists'
         run: |-
           eksctl utils associate-iam-oidc-provider --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --approve
-          eksctl delete iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --only-missing --approve
           eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml
+          eksctl delete iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --only-missing --approve
 
   configure-cluster:
     name: Configure Kubernetes resources on the EKS cluster

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -232,7 +232,7 @@ jobs:
         if: steps.create-clusters.outcome == 'failure' && steps.check-for-failure.outputs.reason == 'already-exists'
         run: |-
           eksctl utils associate-iam-oidc-provider --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --approve
-          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml
+          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --override-existing-serviceaccounts
           eksctl delete iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --only-missing --approve
 
   configure-cluster:

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -290,7 +290,7 @@ jobs:
       - id: deploy-load-balancer-role
         name: Deploy permissions for AWS load balancer controller
         run: |-
-          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.0/docs/install/iam_policy.json
           aws iam create-policy \
             --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
             --policy-document file://iam-policy.json || true

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -162,12 +162,10 @@ jobs:
         name: Add name and region dependent params to the eksctl config.
         run: |-
           export CLUSTER_NAME="biomage-$CLUSTER_ENV"
-          export LOAD_BALANCER_ROLE_NAME="eksctl-$CLUSTER_ENV-load-balancer-controller-role"
 
           yq -i '
             .metadata.name = strenv(CLUSTER_NAME) |
-            .metadata.region = strenv(AWS_REGION) |
-            .iam.serviceAccounts[2].roleName = strenv(LOAD_BALANCER_ROLE_NAME)
+            .metadata.region = strenv(AWS_REGION)
           ' infra/config/cluster/cluster-template.yaml
 
           export CUSTOM_CLUSTER_CONFIG="infra/config/cluster/${{ matrix.environment-name }}/custom-cluster-config.yaml"
@@ -301,6 +299,7 @@ jobs:
             --namespace=kube-system \
             --name=aws-load-balancer-controller \
             --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --role-name eksctl-$CLUSTER_ENV-load-balancer-controller-role
             --override-existing-serviceaccounts \
             --approve
 

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -299,7 +299,6 @@ jobs:
             --namespace=kube-system \
             --name=aws-load-balancer-controller \
             --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --role-name eksctl-$CLUSTER_ENV-load-balancer-controller-role \
             --override-existing-serviceaccounts \
             --approve
 

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -167,7 +167,7 @@ jobs:
           yq -i '
             .metadata.name = strenv(CLUSTER_NAME) |
             .metadata.region = strenv(AWS_REGION) |
-            .metadata.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
+            .iam.serviceAccounts[2].metadata.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
           ' infra/config/cluster/cluster-template.yaml
 
           export CUSTOM_CLUSTER_CONFIG="infra/config/cluster/${{ matrix.environment-name }}/custom-cluster-config.yaml"

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -320,8 +320,8 @@ jobs:
             helm repo update
             helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
               --namespace kube-system \
-              --set serviceAccount.create=true \
-              --set serviceAccount.name=aws-load-balancer-controller \
+              --set serviceAccount.create=false \
+              --set serviceAccount.name=kube-system/aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
               --install --wait
 

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -286,7 +286,6 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
-
       - id: deploy-load-balancer-role
         name: Deploy permissions for AWS load balancer controller
         run: |-

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -299,7 +299,7 @@ jobs:
             --namespace=kube-system \
             --name=aws-load-balancer-controller \
             --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --role-name eksctl-$CLUSTER_ENV-load-balancer-controller-role
+            --role-name eksctl-$CLUSTER_ENV-load-balancer-controller-role \
             --override-existing-serviceaccounts \
             --approve
 

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -159,12 +159,15 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - id: fill-metadata
-        name: Add name and region to the eksctl file.
+        name: Add name and region dependent params to the eksctl config.
         run: |-
           export CLUSTER_NAME="biomage-$CLUSTER_ENV"
+          export LOAD_BALANCER_ROLE_NAME="eksctl-$CLUSTER_ENV-load-balancer-controller-role"
+
           yq -i '
             .metadata.name = strenv(CLUSTER_NAME) |
-            .metadata.region = strenv(AWS_REGION)
+            .metadata.region = strenv(AWS_REGION) |
+            .iam.serviceAccounts[1].metadata.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
           ' infra/config/cluster/cluster-template.yaml
 
           export CUSTOM_CLUSTER_CONFIG="infra/config/cluster/${{ matrix.environment-name }}/custom-cluster-config.yaml"
@@ -233,7 +236,7 @@ jobs:
         run: |-
           eksctl utils associate-iam-oidc-provider --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --approve
           eksctl delete iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --only-missing --approve
-          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --role-name "eksctl-$CLUSTER_ENV-load-balancer-controller-role"
+          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml
 
   configure-cluster:
     name: Configure Kubernetes resources on the EKS cluster

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -167,7 +167,7 @@ jobs:
           yq -i '
             .metadata.name = strenv(CLUSTER_NAME) |
             .metadata.region = strenv(AWS_REGION) |
-            .iam.serviceAccounts[2].metadata.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
+            .iam.serviceAccounts[2].wellKnownPolicies.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
           ' infra/config/cluster/cluster-template.yaml
 
           export CUSTOM_CLUSTER_CONFIG="infra/config/cluster/${{ matrix.environment-name }}/custom-cluster-config.yaml"

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -167,7 +167,7 @@ jobs:
           yq -i '
             .metadata.name = strenv(CLUSTER_NAME) |
             .metadata.region = strenv(AWS_REGION) |
-            .iam.serviceAccounts[2].wellKnownPolicies.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
+            .iam.serviceAccounts[2].roleName = strenv(LOAD_BALANCER_ROLE_NAME)
           ' infra/config/cluster/cluster-template.yaml
 
           export CUSTOM_CLUSTER_CONFIG="infra/config/cluster/${{ matrix.environment-name }}/custom-cluster-config.yaml"

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -320,7 +320,7 @@ jobs:
             helm repo update
             helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
               --namespace kube-system \
-              --set serviceAccount.create=false \
+              --set serviceAccount.create=true \
               --set serviceAccount.name=aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
               --install --wait

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -321,7 +321,7 @@ jobs:
             helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
               --namespace kube-system \
               --set serviceAccount.create=false \
-              --set serviceAccount.name=kube-system/aws-load-balancer-controller \
+              --set serviceAccount.name=aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
               --install --wait
 

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -232,8 +232,8 @@ jobs:
         if: steps.create-clusters.outcome == 'failure' && steps.check-for-failure.outputs.reason == 'already-exists'
         run: |-
           eksctl utils associate-iam-oidc-provider --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --approve
-          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml
           eksctl delete iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --only-missing --approve
+          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --role-name "eksctl-$CLUSTER_ENV-load-balancer-controller-role"
 
   configure-cluster:
     name: Configure Kubernetes resources on the EKS cluster
@@ -285,6 +285,7 @@ jobs:
         run: |-
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
+
 
       - id: deploy-load-balancer-role
         name: Deploy permissions for AWS load balancer controller

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -232,7 +232,7 @@ jobs:
         if: steps.create-clusters.outcome == 'failure' && steps.check-for-failure.outputs.reason == 'already-exists'
         run: |-
           eksctl utils associate-iam-oidc-provider --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --approve
-          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --override-existing-serviceaccounts
+          eksctl create iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml
           eksctl delete iamserviceaccount --config-file=/tmp/cluster-$CLUSTER_ENV.yaml --only-missing --approve
 
   configure-cluster:
@@ -286,21 +286,6 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: deploy-load-balancer-role
-        name: Deploy permissions for AWS load balancer controller
-        run: |-
-          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
-          aws iam create-policy \
-            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --policy-document file://iam-policy.json || true
-          eksctl create iamserviceaccount \
-            --cluster=biomage-$CLUSTER_ENV \
-            --namespace=kube-system \
-            --name=aws-load-balancer-controller \
-            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --override-existing-serviceaccounts \
-            --approve
-
       # we need to retry this due to an active issue with the AWS Load Balancer Controller
       # where there are intermittent failures that are only fixable by retrying
       # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
@@ -322,6 +307,21 @@ jobs:
               --set serviceAccount.name=aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
               --install --wait
+
+      - id: deploy-load-balancer-role
+        name: Deploy permissions for AWS load balancer controller
+        run: |-
+          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+          aws iam create-policy \
+            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --policy-document file://iam-policy.json || true
+          eksctl create iamserviceaccount \
+            --cluster=biomage-$CLUSTER_ENV \
+            --namespace=kube-system \
+            --name=aws-load-balancer-controller \
+            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --override-existing-serviceaccounts \
+            --approve
 
       - id: platform-public-facing
         name: Get config for whether platform should be public facing

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -286,6 +286,21 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
+      - id: deploy-load-balancer-role
+        name: Deploy permissions for AWS load balancer controller
+        run: |-
+          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+          aws iam create-policy \
+            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --policy-document file://iam-policy.json || true
+          eksctl create iamserviceaccount \
+            --cluster=biomage-$CLUSTER_ENV \
+            --namespace=kube-system \
+            --name=aws-load-balancer-controller \
+            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
+            --override-existing-serviceaccounts \
+            --approve
+
       # we need to retry this due to an active issue with the AWS Load Balancer Controller
       # where there are intermittent failures that are only fixable by retrying
       # see issue at https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2071
@@ -307,21 +322,6 @@ jobs:
               --set serviceAccount.name=aws-load-balancer-controller \
               --set clusterName=biomage-$CLUSTER_ENV \
               --install --wait
-
-      - id: deploy-load-balancer-role
-        name: Deploy permissions for AWS load balancer controller
-        run: |-
-          curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
-          aws iam create-policy \
-            --policy-name AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --policy-document file://iam-policy.json || true
-          eksctl create iamserviceaccount \
-            --cluster=biomage-$CLUSTER_ENV \
-            --namespace=kube-system \
-            --name=aws-load-balancer-controller \
-            --attach-policy-arn=arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:policy/AWSLoadBalancerControllerIAMPolicy-$CLUSTER_ENV \
-            --override-existing-serviceaccounts \
-            --approve
 
       - id: platform-public-facing
         name: Get config for whether platform should be public facing

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -167,7 +167,7 @@ jobs:
           yq -i '
             .metadata.name = strenv(CLUSTER_NAME) |
             .metadata.region = strenv(AWS_REGION) |
-            .iam.serviceAccounts[1].metadata.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
+            .metadata.roleName = strenv(LOAD_BALANCER_ROLE_NAME)
           ' infra/config/cluster/cluster-template.yaml
 
           export CUSTOM_CLUSTER_CONFIG="infra/config/cluster/${{ matrix.environment-name }}/custom-cluster-config.yaml"

--- a/infra/config/cluster/cluster-template.yaml
+++ b/infra/config/cluster/cluster-template.yaml
@@ -23,6 +23,10 @@ iam:
           aws-usage: cluster-ops
       attachPolicyARNs:
       - "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+    - metadata:
+        name: aws-load-balancer-controller
+        namespace: kube-system
+        roleName: filled-in-by-ci
 
 # if you add or remove items under managedNodeGroups, make sure you update customized cluster
 # config for each of the Github environments under infra/config/cluster

--- a/infra/config/cluster/cluster-template.yaml
+++ b/infra/config/cluster/cluster-template.yaml
@@ -26,8 +26,7 @@ iam:
     - metadata:
         name: aws-load-balancer-controller
         namespace: kube-system
-      wellKnownPolicies:
-        roleName: filled-in-by-ci
+      roleName: filled-in-by-ci
 
 # if you add or remove items under managedNodeGroups, make sure you update customized cluster
 # config for each of the Github environments under infra/config/cluster

--- a/infra/config/cluster/cluster-template.yaml
+++ b/infra/config/cluster/cluster-template.yaml
@@ -26,6 +26,7 @@ iam:
     - metadata:
         name: aws-load-balancer-controller
         namespace: kube-system
+      wellKnownPolicies:
         roleName: filled-in-by-ci
 
 # if you add or remove items under managedNodeGroups, make sure you update customized cluster

--- a/infra/config/cluster/cluster-template.yaml
+++ b/infra/config/cluster/cluster-template.yaml
@@ -23,10 +23,6 @@ iam:
           aws-usage: cluster-ops
       attachPolicyARNs:
       - "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-    - metadata:
-        name: aws-load-balancer-controller
-        namespace: kube-system
-      roleName: filled-in-by-ci
 
 # if you add or remove items under managedNodeGroups, make sure you update customized cluster
 # config for each of the Github environments under infra/config/cluster


### PR DESCRIPTION
# Background
deploy-infra action last run: https://github.com/biomage-org/iac/actions/runs/4566944269

This is currently active in staging, and it seems to be working fine.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2414

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR