### PR TITLE
Pin flux cli version

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -514,9 +514,9 @@ jobs:
           kubectl create configmap account-config --from-file=infra/config/account-config.yaml -n flux-system -o yaml --dry-run | kubectl apply -f -
 
       - id: install-flux-v2
-        name: Install flux CLI
+        name: Install flux CLI version 0.41.0
         run: |-
-          curl -s https://fluxcd.io/install.sh | sudo bash
+          curl -s https://fluxcd.io/install.sh | sudo FLUX_VERSION=0.41.0 bash
 
       - id: delete-old-flux-github-deploy-key
         name: Attempt to delete previous github flux deploy key


### PR DESCRIPTION
# Background
Based on the response to this https://github.com/fluxcd/flux2/discussions/3679 I'm adding version pinning for the flux cli using the format mentioned [here](https://github.com/fluxcd/flux2/discussions/489#discussioncomment-3858081).

#### Link to issue 
N/A

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR