### PR TITLE
running scale down out of fargate for default profiles

### DIFF
--- a/infra/config/cluster/cluster-template.yaml
+++ b/infra/config/cluster/cluster-template.yaml
@@ -15,14 +15,14 @@ iam:
           - Effect: Deny
             Action:
               - "s3:*"
-            Resource: '*'
+            Resource: "*"
     - metadata:
         name: aws-node
         namespace: kube-system
         labels:
           aws-usage: cluster-ops
       attachPolicyARNs:
-      - "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
 
 # if you add or remove items under managedNodeGroups, make sure you update customized cluster
 # config for each of the Github environments under infra/config/cluster
@@ -50,6 +50,11 @@ fargateProfiles:
   - name: worker-default
     selectors:
       - namespace: worker-default
+        labels:
+          type: worker
+
   - name: pipeline-default
     selectors:
       - namespace: pipeline-default
+        labels:
+          type: pipeline


### PR DESCRIPTION
# Background
#### Link to issue 
There was a missing `type` in the cluster configuration so the scale down jobs for `pipeline-default` and `worker-default` were running in fargate incurring into extra costs.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR