### PR TITLE
add max session duration

### DIFF
--- a/infra/cf-github-oidc.yaml
+++ b/infra/cf-github-oidc.yaml
@@ -8,6 +8,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: ci-iac-role
+      MaxSessionDuration: 7200
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
# Background
Needs to increase OIDC maximum session duration from 60 min to 2 hours, because configure cluster may take about an hour to complete.

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR