### PR TITLE
Removing CF circular dependency - Step 4

### DIFF
--- a/cf/cognito-case-insensitive.yaml
+++ b/cf/cognito-case-insensitive.yaml
@@ -21,48 +21,8 @@ Outputs:
     Value: !GetAtt UserPool.ProviderName
     Export:
       Name: !Sub 'biomage-user-pool-case-insensitive-${Environment}::UserPoolProviderName'
-  UIRoleArn:
-    Description: ARN of the UI role
-    Value: !GetAtt UIRole.Arn
-    Export:
-      Name: !Sub 'biomage-user-pool-case-insensitive-${Environment}::UIRoleArn'
 
 Resources:
-  UIRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      RoleName: !Sub "biomage-user-pool-case-insensitive-ui-auth-user-role-${Environment}"
-      AssumeRolePolicyDocument: |-
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "",
-              "Effect": "Allow",
-              "Principal": {
-                "Federated": "cognito-identity.amazonaws.com"
-              },
-              "Action": "sts:AssumeRoleWithWebIdentity",
-              "Condition": {
-                "ForAnyValue:StringLike": {
-                  "cognito-identity.amazonaws.com:amr": "authenticated"
-                }
-              }
-            }
-          ]
-        }
-      Path: /
-      Policies:
-        - PolicyName: !Sub "can-execute-lambda-${Environment}"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "lambda:InvokeFunction"
-                Resource:
-                  Fn::ImportValue: !Sub PostRegisterLambdaArn-${Environment}
-
   SMSRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/cf/cognito-case-insensitive.yaml
+++ b/cf/cognito-case-insensitive.yaml
@@ -9,10 +9,7 @@ Parameters:
       - development
       - staging
       - production
-    Description: The environment for which the buckets need to be created.
-
-Conditions:
-  isProd: !Equals [!Ref Environment, "production"]
+    Description: The environment for which Cognito needs to be created.
 
 Outputs:
   UserPoolId:
@@ -24,48 +21,8 @@ Outputs:
     Value: !GetAtt UserPool.ProviderName
     Export:
       Name: !Sub 'biomage-user-pool-case-insensitive-${Environment}::UserPoolProviderName'
-  UIRoleArn:
-    Description: ARN of the UI role
-    Value: !GetAtt UIRole.Arn
-    Export:
-      Name: !Sub 'biomage-user-pool-case-insensitive-${Environment}::UIRoleArn'
 
 Resources:
-  UIRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      RoleName: !Sub "biomage-user-pool-case-insensitive-ui-auth-user-role-${Environment}"
-      AssumeRolePolicyDocument: |-
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "",
-              "Effect": "Allow",
-              "Principal": {
-                "Federated": "cognito-identity.amazonaws.com"
-              },
-              "Action": "sts:AssumeRoleWithWebIdentity",
-              "Condition": {
-                "ForAnyValue:StringLike": {
-                  "cognito-identity.amazonaws.com:amr": "authenticated"
-                }
-              }
-            }
-          ]
-        }
-      Path: /
-      Policies:
-        - PolicyName: !Sub "can-execute-lambda-${Environment}"
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "lambda:InvokeFunction"
-                Resource:
-                  Fn::ImportValue: !Sub PostRegisterLambdaArn-${Environment}
-
   SMSRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/cf/cognito-case-insensitive.yaml
+++ b/cf/cognito-case-insensitive.yaml
@@ -21,8 +21,48 @@ Outputs:
     Value: !GetAtt UserPool.ProviderName
     Export:
       Name: !Sub 'biomage-user-pool-case-insensitive-${Environment}::UserPoolProviderName'
+  UIRoleArn:
+    Description: ARN of the UI role
+    Value: !GetAtt UIRole.Arn
+    Export:
+      Name: !Sub 'biomage-user-pool-case-insensitive-${Environment}::UIRoleArn'
 
 Resources:
+  UIRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "biomage-user-pool-case-insensitive-ui-auth-user-role-${Environment}"
+      AssumeRolePolicyDocument: |-
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "",
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "cognito-identity.amazonaws.com"
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "ForAnyValue:StringLike": {
+                  "cognito-identity.amazonaws.com:amr": "authenticated"
+                }
+              }
+            }
+          ]
+        }
+      Path: /
+      Policies:
+        - PolicyName: !Sub "can-execute-lambda-${Environment}"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "lambda:InvokeFunction"
+                Resource:
+                  Fn::ImportValue: !Sub PostRegisterLambdaArn-${Environment}
+
   SMSRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/cf/userpoolclient.yaml
+++ b/cf/userpoolclient.yaml
@@ -61,31 +61,6 @@ Resources:
       SupportedIdentityProviders:
         - COGNITO
 
-  FileUploadIdentityPool:
-    Type: AWS::Cognito::IdentityPool
-    Properties:
-      IdentityPoolName: !Sub "file-upload-identity-pool-${Environment}-${SandboxID}"
-      AllowUnauthenticatedIdentities: false
-      CognitoIdentityProviders:
-        - ClientId: !Ref UserPoolClientCluster
-          ProviderName:
-            Fn::ImportValue: !Sub "biomage-user-pool-case-insensitive-${Environment}::UserPoolProviderName"
-
-  # TODO: this will have to be refactored once authentication is done.
-  # this will have to work with attribute-based access control or role-based
-  # access control so we can limit the user to only upload to certain folders
-  # on S3 depending on their instutiton/name/etc.
-  #
-  # see https://docs.aws.amazon.com/cognito/latest/developerguide/attributes-for-access-control.html
-  # and https://docs.aws.amazon.com/cognito/latest/developerguide/role-based-access-control.html
-  FileUploadIdentityPoolRoleAttachment:
-    Type: AWS::Cognito::IdentityPoolRoleAttachment
-    Properties:
-      IdentityPoolId: !Ref FileUploadIdentityPool
-      Roles:
-        "authenticated":
-          Fn::ImportValue: !Sub "biomage-user-pool-case-insensitive-${Environment}::UIRoleArn"
-
   IdentityPool:
     Type: AWS::Cognito::IdentityPool
     Properties:

--- a/cf/userpoolclient.yaml
+++ b/cf/userpoolclient.yaml
@@ -85,3 +85,21 @@ Resources:
       Roles:
         "authenticated":
           Fn::ImportValue: !Sub "biomage-user-pool-case-insensitive-${Environment}::UIRoleArn"
+
+  IdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      IdentityPoolName: !Sub "identity-pool-${Environment}-${SandboxID}"
+      AllowUnauthenticatedIdentities: false
+      CognitoIdentityProviders:
+        - ClientId: !Ref UserPoolClientCluster
+          ProviderName:
+            Fn::ImportValue: !Sub "biomage-user-pool-case-insensitive-${Environment}::UserPoolProviderName"
+
+  IdentityPoolRoleAttachment:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId: !Ref IdentityPool
+      Roles:
+        "authenticated":
+          Fn::ImportValue: !Sub "InvokePostRegisterLambdaRoleArn-${Environment}"


### PR DESCRIPTION
# Background
This is **step 4 of 4** to remove circular dependency in CF deployment:

1. Duplicate UI role ARN in used in userpoolclient.yaml, moving it to be created in and exported by post-register-lambda.
2. Make userpoolclient use the exported permissions from post-register-lambda.
3. Remove dependency from userpoolclient.
4. Remove dependency from Cognito.

#### Link to issue
https://github.com/biomage-org/issues/issues/92

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR