### PR TITLE
Add default case to run when merging

### DIFF
--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -47,29 +47,61 @@ jobs:
       - id: set-env-type
         name: Set up environment type
         run: |-
-          if [ "${ENVIRONMENT_TYPE}" = "staging" ]; then
+          WORKFLOW_ENV_TYPE=""
+
+          # When merging a PR, the value of github.event.inputs.environment_type is empty
+          # We want this to be "staging and production"
+          WORKFLOW_ENV_TYPE_ON_MERGE="staging and production"
+
+          # If github.event.inputs.environment_type is not empty, we're running this workflow manually
+          # In that case, set WORKFLOW_ENV accordingly
+          if [ ! -z "${INPUT_ENVIRONMENT_TYPE}" ]; then
+            WORKFLOW_ENV_TYPE="${INPUT_ENVIRONMENT_TYPE}"
+          else
+            WORKFLOW_ENV_TYPE="$WORKFLOW_ENV_TYPE_ON_MERGE"
+          fi
+
+          echo "Using env type: $WORKFLOW_ENV_TYPE"
+
+          if [ "$WORKFLOW_ENV_TYPE" = "staging" ]; then
             echo 'env-type=["staging"]' >> $GITHUB_OUTPUT
-          elif [ "${ENVIRONMENT_TYPE}" = "production" ]; then
+          elif [ "$WORKFLOW_ENV_TYPE" = "production" ]; then
             echo 'env-type=["production"]' >> $GITHUB_OUTPUT
-          elif [ "${ENVIRONMENT_TYPE}" = "staging and production" ]; then
+          elif [ "$WORKFLOW_ENV_TYPE" = "staging and production" ]; then
             echo 'env-type=["staging", "production"]' >> $GITHUB_OUTPUT
           fi
         env:
-            ENVIRONMENT_TYPE: ${{ github.event.inputs.environment_type }}
+            INPUT_ENVIRONMENT_TYPE: ${{ github.event.inputs.environment_type }}
       - id: set-env-name
         name: Set up environment name
         run: |-
-          if [ "${ENVIRONMENT_NAME}" = "all" ]; then
+          WORKFLOW_ENV_NAME=""
+
+          # When merging a PR, the value of github.event.inputs.environment_name is empty.
+          # we want this to be "all"
+          WORKFLOW_ENV_NAME_ON_MERGE="all"
+
+          # If github.event.inputs.environment_type is not empty, we're running this workflow manually.
+          # In that case, set WORKFLOW_ENV according to the choice
+          if [ ! -z "${INPUT_ENVIRONMENT_NAME}" ]; then
+            WORKFLOW_ENV_NAME="${INPUT_ENVIRONMENT_NAME}"
+          else
+            WORKFLOW_ENV_NAME="$WORKFLOW_ENV_NAME_ON_MERGE"
+          fi
+
+          echo "Using env name: $WORKFLOW_ENV_NAME"
+
+          if [ "$WORKFLOW_ENV_NAME" = "all" ]; then
             echo 'env-name=["Biomage", "trv", "alabs"]' >> $GITHUB_OUTPUT
-          elif [ "${ENVIRONMENT_NAME}" = "trv" ]; then
+          elif [ "$WORKFLOW_ENV_NAME" = "trv" ]; then
             echo 'env-name=["trv"]' >> $GITHUB_OUTPUT
-          elif [ "${ENVIRONMENT_NAME}" = "alabs" ]; then
+          elif [ "$WORKFLOW_ENV_NAME" = "alabs" ]; then
             echo 'env-name=["alabs"]' >> $GITHUB_OUTPUT
-          elif [ "${ENVIRONMENT_NAME}" = "Biomage" ]; then
+          elif [ "$WORKFLOW_ENV_NAME" = "Biomage" ]; then
             echo 'env-name=["Biomage"]' >> $GITHUB_OUTPUT
           fi
         env:
-            ENVIRONMENT_NAME: ${{ github.event.inputs.environment_name }}
+            INPUT_ENVIRONMENT_NAME: ${{ github.event.inputs.environment_name }}
 
   check-secrets:
     name: Check secrets


### PR DESCRIPTION
# Background
PR #163 introduced a bug. When merging CF changes, the values of the `github.inputs.environment_type` and `github.inputs.environment_name` is empty as it is not set by `on: push` action. This PR adds a default value to be used when merging.

This bug is seen on this action: https://github.com/biomage-org/iac/actions/runs/5143223854

#### Link to issue
N/A

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR