### PR TITLE
Add sandbox id to AuthedRole

### DIFF
--- a/cf/userpoolclient.yaml
+++ b/cf/userpoolclient.yaml
@@ -81,7 +81,7 @@ Resources:
   AuthedUserRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: !Sub "authed-user-role-${Environment}"
+      RoleName: !Sub "authed-user-role-${Environment}-${SandboxID}"
       AssumeRolePolicyDocument: |-
         {
           "Version": "2012-10-17",


### PR DESCRIPTION
# Background
There's an issue creating role when staging. This is because the same role is being created again. This PR adds the sandbox id to the role name, so a separate role can be added for each env.

#### Link to issue
N/A

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR