### PR TITLE
Add new Github OIDC thumbprint

### DIFF
--- a/infra/cf-github-oidc.yaml
+++ b/infra/cf-github-oidc.yaml
@@ -31,6 +31,7 @@ Resources:
         - sts.amazonaws.com
       ThumbprintList:
         - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
 
 Outputs:
   Role:


### PR DESCRIPTION
# Background
The previous thumbprint that Github was using is expired (see https://github.com/aws-actions/configure-aws-credentials/issues/357#issuecomment-1610927373). There's a new thumbprint that needs to be added (see https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/)

#### Link to issue 
https://github.com/biomage-org/iac/actions/runs/5411277337/jobs/9833813781

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR